### PR TITLE
windows support

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-arg=/STACK:8388608"]

--- a/src/ephemeris.rs
+++ b/src/ephemeris.rs
@@ -36,7 +36,8 @@ type Result<T> = std::result::Result<T, InvalidEphemeris>;
 
 /// Various statuses that an ephemeris can be in
 #[derive(Copy, Clone, Debug)]
-#[repr(u32)]
+#[cfg_attr(windows, repr(i32))]
+#[cfg_attr(not(windows), repr(u32))]
 pub enum Status {
     Null = c_bindings::ephemeris_status_t_EPH_NULL,
     Invalid = c_bindings::ephemeris_status_t_EPH_INVALID,


### PR DESCRIPTION
Fixes a compilation issue on Windows and adds a stack size linker flag which is necessary to run the tests (sadly, this flag is also needed if you are linking against `swiftnav-rs` on windows).