### PR TITLE
New release changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,12 @@
 [package]
 name = "swiftnav-rs"
-version = "0.1.0"
-authors = ["Joseph Angelo <joseph.angelo@swift-nav.com>"]
+version = "0.2.0"
+authors = ["Swift Navigation <dev@swiftnav.com>"]
 edition = "2018"
-description = "Low level GNSS decoding and positioning"
+description = "GNSS positioning and related utilities"
 readme = "README.md"
 repository = "https://github.com/swift-nav/swiftnav-rs"
 license = "LGPL-3.0"
-
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # swiftnav-rs
 
-An idiomatic Rust wrapper around the C library [`libswiftnav`](https://github.com/swift-nav/libswiftnav), which provides
-general GNSS related functionality.
+`swiftnav-rs` is a crate that implements GNSS utility functions for use by software-defined GNSS receivers or software requiring GNSS functionality. It is intended to be as portable as possible and has limited dependancies
+
+`swiftnav-rs` does not provide any functionality for communicating with Swift
+Navigation receivers.  See [libsbp](https://github.com/swift-nav/libsbp) to
+communicate with receivers using Swift Binary Protocol (SBP).
 
 ## License
 This crate is distributed under the terms of the LGPLv3, full details are


### PR DESCRIPTION
Update the cargo version to `0.2.0` and make the README a bit more clear. Will manually tag v0.2.0 after this is merged.