### PR TITLE
Added functions for constructing objects from SBP messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,11 @@ readme = "README.md"
 repository = "https://github.com/swift-nav/swiftnav-rs"
 license = "LGPL-3.0"
 
+[features]
+sbp-conversions = ["sbp"]
+
 [dependencies]
+sbp = { git = "https://github.com/swift-nav/libsbp.git", rev="51660bd02f18216aef7abcdebf27fec72a93c161", optional = true }
 
 [build-dependencies]
 bindgen = "0.57"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
       steps {
         gitPrep()
         script {
-          sh("cargo check")
+          sh("cargo check --all-targets --all-features")
         }
       }
     }
@@ -50,7 +50,7 @@ pipeline {
           agent { dockerfile { reuseNode true } }
           steps {
             script {
-              sh("cargo clippy")
+              sh("cargo clippy --all-targets --all-features")
             }
           }
         }

--- a/src/ephemeris.rs
+++ b/src/ephemeris.rs
@@ -371,7 +371,7 @@ impl Ephemeris {
         Ok(doppler)
     }
 
-    pub fn get_sid(&self) -> std::result::Result<GnssSignal, InvalidGnssSignal> {
+    pub fn get_sid(&self) -> Result<GnssSignal, InvalidGnssSignal> {
         GnssSignal::from_gnss_signal_t(self.0.sid)
     }
 
@@ -396,6 +396,133 @@ impl Ephemeris {
     /// Check if this this ephemeris is healthy
     pub fn is_healthy(&self, code: &Code) -> bool {
         unsafe { c_bindings::ephemeris_healthy(&self.0, code.to_code_t()) }
+    }
+}
+
+#[cfg(feature = "sbp-conversions")]
+mod sbp_error {
+    use crate::{signal::InvalidGnssSignal, time::InvalidGpsTime};
+    use std::error::Error;
+    use std::fmt;
+
+    #[derive(Debug, Copy, Clone, PartialOrd, PartialEq)]
+    pub enum EphemerisDecodeError {
+        InvalidTime(InvalidGpsTime),
+        InvalidSignal(InvalidGnssSignal),
+    }
+
+    impl fmt::Display for EphemerisDecodeError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                EphemerisDecodeError::InvalidTime(time_err) => time_err.fmt(f),
+                EphemerisDecodeError::InvalidSignal(sig_err) => sig_err.fmt(f),
+            }
+        }
+    }
+
+    impl Error for EphemerisDecodeError {}
+
+    impl From<InvalidGpsTime> for EphemerisDecodeError {
+        fn from(other: InvalidGpsTime) -> EphemerisDecodeError {
+            EphemerisDecodeError::InvalidTime(other)
+        }
+    }
+
+    impl From<InvalidGnssSignal> for EphemerisDecodeError {
+        fn from(other: InvalidGnssSignal) -> EphemerisDecodeError {
+            EphemerisDecodeError::InvalidSignal(other)
+        }
+    }
+}
+
+#[cfg(feature = "sbp-conversions")]
+pub use sbp_error::EphemerisDecodeError;
+
+#[cfg(feature = "sbp-conversions")]
+impl TryFrom<sbp::messages::observation::MsgEphemerisGPS> for Ephemeris {
+    type Error = EphemerisDecodeError;
+
+    fn try_from(
+        eph: sbp::messages::observation::MsgEphemerisGPS,
+    ) -> Result<Ephemeris, EphemerisDecodeError> {
+        Ok(Ephemeris::new(
+            GnssSignal::from_sbp(eph.common.sid)?,
+            GpsTime::from_sbp_secs(eph.common.toe)?,
+            eph.common.ura,
+            eph.common.fit_interval,
+            eph.common.valid,
+            eph.common.health_bits,
+            0,
+            EphemerisTerms::new_kepler(
+                Constellation::Gps,
+                [eph.tgd, 0.],
+                eph.c_rc as f64,
+                eph.c_rs as f64,
+                eph.c_uc as f64,
+                eph.c_us as f64,
+                eph.c_ic as f64,
+                eph.c_is as f64,
+                eph.dn,
+                eph.m0,
+                eph.ecc,
+                eph.sqrta,
+                eph.omega0,
+                eph.omegadot,
+                eph.w,
+                eph.inc,
+                eph.inc_dot,
+                eph.af0 as f64,
+                eph.af1 as f64,
+                eph.af2 as f64,
+                GpsTime::from_sbp_secs(eph.toc)?,
+                eph.iodc,
+                eph.iode as u16,
+            ),
+        ))
+    }
+}
+
+#[cfg(feature = "sbp-conversions")]
+impl TryFrom<sbp::messages::observation::MsgEphemerisGal> for Ephemeris {
+    type Error = EphemerisDecodeError;
+
+    fn try_from(
+        eph: sbp::messages::observation::MsgEphemerisGal,
+    ) -> Result<Ephemeris, EphemerisDecodeError> {
+        Ok(Ephemeris::new(
+            GnssSignal::from_sbp(eph.common.sid)?,
+            GpsTime::from_sbp_secs(eph.common.toe)?,
+            eph.common.ura,
+            eph.common.fit_interval,
+            eph.common.valid,
+            eph.common.health_bits,
+            eph.source,
+            EphemerisTerms::new_kepler(
+                Constellation::Gal,
+                [eph.bgd_e1e5a, eph.bgd_e1e5b],
+                eph.c_rc as f64,
+                eph.c_rs as f64,
+                eph.c_uc as f64,
+                eph.c_us as f64,
+                eph.c_ic as f64,
+                eph.c_is as f64,
+                eph.dn,
+                eph.m0,
+                eph.ecc,
+                eph.sqrta,
+                eph.omega0,
+                eph.omegadot,
+                eph.w,
+                eph.inc,
+                eph.inc_dot,
+                eph.af0 as f64,
+                eph.af1 as f64,
+                eph.af2 as f64,
+                GpsTime::from_sbp_secs(eph.toc)?,
+                eph.iodc,
+                eph.iode as u16,
+            ),
+        ))
     }
 }
 

--- a/src/ephemeris.rs
+++ b/src/ephemeris.rs
@@ -439,15 +439,17 @@ mod sbp_error {
 pub use sbp_error::EphemerisDecodeError;
 
 #[cfg(feature = "sbp-conversions")]
-impl TryFrom<sbp::messages::observation::MsgEphemerisGPS> for Ephemeris {
+impl std::convert::TryFrom<sbp::messages::observation::MsgEphemerisGPS> for Ephemeris {
     type Error = EphemerisDecodeError;
 
     fn try_from(
         eph: sbp::messages::observation::MsgEphemerisGPS,
     ) -> Result<Ephemeris, EphemerisDecodeError> {
+        use std::convert::TryInto;
+
         Ok(Ephemeris::new(
-            GnssSignal::from_sbp(eph.common.sid)?,
-            GpsTime::from_sbp_secs(eph.common.toe)?,
+            eph.common.sid.try_into()?,
+            eph.common.toe.try_into()?,
             eph.common.ura,
             eph.common.fit_interval,
             eph.common.valid,
@@ -474,7 +476,7 @@ impl TryFrom<sbp::messages::observation::MsgEphemerisGPS> for Ephemeris {
                 eph.af0 as f64,
                 eph.af1 as f64,
                 eph.af2 as f64,
-                GpsTime::from_sbp_secs(eph.toc)?,
+                eph.toc.try_into()?,
                 eph.iodc,
                 eph.iode as u16,
             ),
@@ -483,15 +485,17 @@ impl TryFrom<sbp::messages::observation::MsgEphemerisGPS> for Ephemeris {
 }
 
 #[cfg(feature = "sbp-conversions")]
-impl TryFrom<sbp::messages::observation::MsgEphemerisGal> for Ephemeris {
+impl std::convert::TryFrom<sbp::messages::observation::MsgEphemerisGal> for Ephemeris {
     type Error = EphemerisDecodeError;
 
     fn try_from(
         eph: sbp::messages::observation::MsgEphemerisGal,
     ) -> Result<Ephemeris, EphemerisDecodeError> {
+        use std::convert::TryInto;
+
         Ok(Ephemeris::new(
-            GnssSignal::from_sbp(eph.common.sid)?,
-            GpsTime::from_sbp_secs(eph.common.toe)?,
+            eph.common.sid.try_into()?,
+            eph.common.toe.try_into()?,
             eph.common.ura,
             eph.common.fit_interval,
             eph.common.valid,
@@ -518,7 +522,7 @@ impl TryFrom<sbp::messages::observation::MsgEphemerisGal> for Ephemeris {
                 eph.af0 as f64,
                 eph.af1 as f64,
                 eph.af2 as f64,
-                GpsTime::from_sbp_secs(eph.toc)?,
+                eph.toc.try_into()?,
                 eph.iodc,
                 eph.iode as u16,
             ),

--- a/src/navmeas.rs
+++ b/src/navmeas.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 const NAV_MEAS_FLAG_CODE_VALID: u16 = 1 << 0;
 const NAV_MEAS_FLAG_MEAS_DOPPLER_VALID: u16 = 1 << 2;
 const NAV_MEAS_FLAG_CN0_VALID: u16 = 1 << 5;
+#[allow(dead_code)]
 const NAV_MEAS_FLAG_RAIM_EXCLUSION: u16 = 1 << 6;
 
 /// Represents a single raw GNSS measurement

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -395,6 +395,13 @@ impl Code {
     }
 }
 
+#[cfg(feature = "sbp-conversions")]
+impl TryFrom<u8> for Code {
+    fn try_from(value: u8) -> Result<Code, InvalidCode> {
+        Self::from_code_t(value as c_bindings::code_t)
+    }
+}
+
 /// GNSS Signal identifier
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct GnssSignal(c_bindings::gnss_signal_t);
@@ -466,6 +473,15 @@ impl GnssSignal {
     /// Get the carrier frequency of the signal
     pub fn carrier_frequency(&self) -> f64 {
         unsafe { c_bindings::sid_to_carr_freq(self.0) }
+    }
+}
+
+#[cfg(feature = "sbp-conversions")]
+impl TryFrom<sbp::messages::gnss::GnssSignal> for GnssSignal {
+    type Error = InvalidGnssSignal;
+
+    fn try_from(value: sbp::messages::gnss::GnssSignal) -> Result<GnssSignal, InvalidGnssSignal> {
+        GnssSignal::new(value.sat as u16, Code::from_sbp(value.code)?)
     }
 }
 

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -29,7 +29,7 @@ pub enum Constellation {
 
 /// Invalid constellation integer value
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-struct InvalidConstellation(c_bindings::constellation_t);
+pub struct InvalidConstellation(c_bindings::constellation_t);
 
 impl fmt::Display for InvalidConstellation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -79,6 +79,13 @@ impl Constellation {
             ))
         };
         c_str.to_string_lossy()
+    }
+}
+
+impl std::convert::TryFrom<u8> for Constellation {
+    type Error = InvalidConstellation;
+    fn try_from(value: u8) -> Result<Constellation, InvalidConstellation> {
+        Self::from_constellation_t(value as c_bindings::constellation_t)
     }
 }
 
@@ -395,7 +402,6 @@ impl Code {
     }
 }
 
-#[cfg(feature = "sbp-conversions")]
 impl std::convert::TryFrom<u8> for Code {
     type Error = InvalidCode;
     fn try_from(value: u8) -> Result<Code, InvalidCode> {

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -396,7 +396,8 @@ impl Code {
 }
 
 #[cfg(feature = "sbp-conversions")]
-impl TryFrom<u8> for Code {
+impl std::convert::TryFrom<u8> for Code {
+    type Error = InvalidCode;
     fn try_from(value: u8) -> Result<Code, InvalidCode> {
         Self::from_code_t(value as c_bindings::code_t)
     }
@@ -477,11 +478,13 @@ impl GnssSignal {
 }
 
 #[cfg(feature = "sbp-conversions")]
-impl TryFrom<sbp::messages::gnss::GnssSignal> for GnssSignal {
+impl std::convert::TryFrom<sbp::messages::gnss::GnssSignal> for GnssSignal {
     type Error = InvalidGnssSignal;
 
     fn try_from(value: sbp::messages::gnss::GnssSignal) -> Result<GnssSignal, InvalidGnssSignal> {
-        GnssSignal::new(value.sat as u16, Code::from_sbp(value.code)?)
+        use std::convert::TryInto;
+
+        GnssSignal::new(value.sat as u16, value.code.try_into()?)
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -175,6 +175,25 @@ impl SubAssign<Duration> for GpsTime {
     }
 }
 
+#[cfg(feature = "sbp-conversions")]
+impl TryFrom<sbp::messages::gnss::GPSTime> for GpsTime {
+    type Error = InvalidGpsTime;
+
+    fn try_from(msg: sbp::messages::gnss::GPSTime) -> Result<GpsTime, InvalidGpsTime> {
+        let tow = (msg.tow as f64) * 1e-3 + (msg.ns_residual as f64) * 1e-9;
+        GpsTime::new(msg.wn as i16, tow)
+    }
+}
+
+#[cfg(feature = "sbp-conversions")]
+impl TryFrom<sbp::messages::gnss::GPSTimeSec> for GpsTime {
+    type Error = InvalidGpsTime;
+
+    fn try_from(msg: sbp::messages::gnss::GPSTimeSec) -> Result<GpsTime, InvalidGpsTime> {
+        GpsTime::new(msg.wn as i16, msg.tow as f64)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/time.rs
+++ b/src/time.rs
@@ -176,7 +176,7 @@ impl SubAssign<Duration> for GpsTime {
 }
 
 #[cfg(feature = "sbp-conversions")]
-impl TryFrom<sbp::messages::gnss::GPSTime> for GpsTime {
+impl std::convert::TryFrom<sbp::messages::gnss::GPSTime> for GpsTime {
     type Error = InvalidGpsTime;
 
     fn try_from(msg: sbp::messages::gnss::GPSTime) -> Result<GpsTime, InvalidGpsTime> {
@@ -186,7 +186,7 @@ impl TryFrom<sbp::messages::gnss::GPSTime> for GpsTime {
 }
 
 #[cfg(feature = "sbp-conversions")]
-impl TryFrom<sbp::messages::gnss::GPSTimeSec> for GpsTime {
+impl std::convert::TryFrom<sbp::messages::gnss::GPSTimeSec> for GpsTime {
     type Error = InvalidGpsTime;
 
     fn try_from(msg: sbp::messages::gnss::GPSTimeSec) -> Result<GpsTime, InvalidGpsTime> {


### PR DESCRIPTION
Added implementations of `TryFrom` for converting message types from libsbp into various types. These definitions are behind a feature flag. The following conversions are included:

- `MsgEphemerisGPS` -> `Ephemeris`
- `MsgEphemerisGal` -> `Ephemeris`
- `MsgObs` -> `Vec<NavigationMeasurement>`
- `u8` -> `Code`
- (SBP) `GnssSignal` -> `GnssSignal`
- (SBP) `GPSTime` -> `GpsTime`
- `GPSTimeSec` -> `GpsTime`

The ephemeris conversion contains conversions of `GnssSignal` and `GpsTime` so has a new error type to signal these compound error cases.