### PR TITLE
build.rs: set CMAKE_INSTALL_PREFIX

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,11 +5,6 @@ use std::path::PathBuf;
 
 fn main() {
     let mut cmake = cmake::Config::new("third-party/libswiftnav/");
-
-    cmake
-        .profile("Release")
-        .define("CMAKE_INSTALL_LIBDIR", "lib");
-
     let dst = cmake.build();
 
     println!("cargo:rustc-link-search=native={}/lib/", dst.display());

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,16 @@
 extern crate bindgen;
 
-use cmake::Config;
 use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let dst = Config::new("third-party/libswiftnav/").build();
+    let mut cmake = cmake::Config::new("third-party/libswiftnav/");
+
+    cmake
+        .profile("Release")
+        .define("CMAKE_INSTALL_LIBDIR", "lib");
+
+    let dst = cmake.build();
 
     println!("cargo:rustc-link-search=native={}/lib/", dst.display());
     println!("cargo:rustc-link-lib=static=swiftnav");

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,12 @@ use std::path::PathBuf;
 
 fn main() {
     let mut cmake = cmake::Config::new("third-party/libswiftnav/");
+    let out_dir = env::var("OUT_DIR").unwrap();
+
+    cmake
+        .profile("Release")
+        .define("CMAKE_INSTALL_PREFIX", out_dir);
+
     let dst = cmake.build();
 
     println!("cargo:rustc-link-search=native={}/lib/", dst.display());


### PR DESCRIPTION
Second part of a two part fix for https://swift-nav.atlassian.net/browse/INFRA-477 -- similar to other -sys crates such as https://github.com/google/shaderc-rs/blob/master/shaderc-sys/build/build.rs -- set the CMAKE_INSTALL_PREFIX to the compile dir so that we don't need root access to run the install target.