### PR TITLE
Add introductory documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,12 @@
 # swiftnav-rs
-`swiftnav-rs` is a library that implements GNSS utility functions to perform
-position estimations. The data used by `swiftnav-rs` typically comes from GNSS
-receiver chips as raw observation and ephemeris data. `swiftnav-rs` is more of
-a "bring your own algorithm" library, it provides a bunch of functionality that
-is useful when processing raw GNSS data, but it provides only limited position
-estimation capabilities. Each module encompasses a single set of functionality,
-and they are meant to be pretty self-explanatory for developers familiar with
-GNSS processing.
 
-GNSS systems are used to estimate the location of the receiver by determining
-the distance between the receiver and several satellites. The satellites send
-out precisely timed periodic messages and the receiver measures the delay
-of those messages. Knowing the location of the satellites at the time of
-transmission and the delays of the messages the receiver is able to determine
-the location of itself in relation to the satellites.
+`swiftnav-rs` is a crate that implements GNSS utility functions for use by
+software-defined GNSS receivers or software requiring GNSS functionality. It is
+intended to be as portable as possible and has limited dependencies.
 
-`swiftnav-rs` does not provide any functionality for communicating with
-receivers made by Swift Navigation, or any manufacturer.
-[libsbp](https://github.com/swift-nav/libsbp) is the library to use if you
-want to communicate with receivers using Swift Binary Protocol (SBP).
-
-## Time
-Time is a very important aspect of GNSS. `swiftnav-rs` defaults to representing
-all times as GPS times. It provides the ability to manipulate GPS time stamps,
-as well as means to convert a GPS time stamp into various other time bases
-(GLONASS time, UTC, MJD).
-
-## Coordinates
-Several different coordinate types have representations and the ability to
-convert between them. Earth centered earth fixed (ECEF), Latitude longitude and
-height (both in radians and degrees), and Azimuth and elevation coordinates are
-available.
-
-## Ephemeris
-Decoding and evaluation of broadcast ephemeris for all major GNSS constellations
-is made available. You are able to calculate the satellite position at a
-particular point in time in several different coordinates.
-
-## Troposphere and Ionosphere
-Two major sources of signal error in GNSS are the troposphere and ionosphere.
-`swiftnav-rs` provides the ability to decode and use the broadcast Klobuchar
-ionosphere model. An implementation of the UNM3m troposphere model is also
-provided.
-
-## Single epoch position solver
-A simple least squares position solver is also included. This allows you to
-get an approximate position with GNSS measurements from a single point in time.
-It uses a least squares algorith, so no state is maintained between solves.
-This can be used to seed your own position estimation algorithm with a rough
-starting location.
+`swiftnav-rs` does not provide any functionality for communicating with Swift
+Navigation receivers.  See [libsbp](https://github.com/swift-nav/libsbp) to
+communicate with receivers using Swift Binary Protocol (SBP).
 
 ## Publishing a new release
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,54 @@
 # swiftnav-rs
+`swiftnav-rs` is a library that implements GNSS utility functions to perform
+position estimations. The data used by `swiftnav-rs` typically comes from GNSS
+receiver chips as raw observation and ephemeris data. `swiftnav-rs` is more of
+a "bring your own algorithm" library, it provides a bunch of functionality that
+is useful when processing raw GNSS data, but it provides only limited position
+estimation capabilities. Each module encompasses a single set of functionality,
+and they are meant to be pretty self-explanatory for developers familiar with
+GNSS processing.
 
-`swiftnav-rs` is a crate that implements GNSS utility functions for use by
-software-defined GNSS receivers or software requiring GNSS functionality. It is
-intended to be as portable as possible and has limited dependencies.
+GNSS systems are used to estimate the location of the receiver by determining
+the distance between the receiver and several satellites. The satellites send
+out precisely timed periodic messages and the receiver measures the delay
+of those messages. Knowing the location of the satellites at the time of
+transmission and the delays of the messages the receiver is able to determine
+the location of itself in relation to the satellites.
 
-`swiftnav-rs` does not provide any functionality for communicating with Swift
-Navigation receivers.  See [libsbp](https://github.com/swift-nav/libsbp) to
-communicate with receivers using Swift Binary Protocol (SBP).
+`swiftnav-rs` does not provide any functionality for communicating with
+receivers made by Swift Navigation, or any manufacturer.
+[libsbp](https://github.com/swift-nav/libsbp) is the library to use if you
+want to communicate with receivers using Swift Binary Protocol (SBP).
+
+## Time
+Time is a very important aspect of GNSS. `swiftnav-rs` defaults to representing
+all times as GPS times. It provides the ability to manipulate GPS time stamps,
+as well as means to convert a GPS time stamp into various other time bases
+(GLONASS time, UTC, MJD).
+
+## Coordinates
+Several different coordinate types have representations and the ability to
+convert between them. Earth centered earth fixed (ECEF), Latitude longitude and
+height (both in radians and degrees), and Azimuth and elevation coordinates are
+available.
+
+## Ephemeris
+Decoding and evaluation of broadcast ephemeris for all major GNSS constellations
+is made available. You are able to calculate the satellite position at a
+particular point in time in several different coordinates.
+
+## Troposphere and Ionosphere
+Two major sources of signal error in GNSS are the troposphere and ionosphere.
+`swiftnav-rs` provides the ability to decode and use the broadcast Klobuchar
+ionosphere model. An implementation of the UNM3m troposphere model is also
+provided.
+
+## Single epoch position solver
+A simple least squares position solver is also included. This allows you to
+get an approximate position with GNSS measurements from a single point in time.
+It uses a least squares algorith, so no state is maintained between solves.
+This can be used to seed your own position estimation algorithm with a rough
+starting location.
 
 ## Publishing a new release
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # swiftnav-rs
 
-`swiftnav-rs` is a crate that implements GNSS utility functions for use by software-defined GNSS receivers or software requiring GNSS functionality. It is intended to be as portable as possible and has limited dependancies
+`swiftnav-rs` is a crate that implements GNSS utility functions for use by
+software-defined GNSS receivers or software requiring GNSS functionality. It is
+intended to be as portable as possible and has limited dependencies.
 
 `swiftnav-rs` does not provide any functionality for communicating with Swift
 Navigation receivers.  See [libsbp](https://github.com/swift-nav/libsbp) to

--- a/src/c_bindings.rs
+++ b/src/c_bindings.rs
@@ -1,3 +1,13 @@
+// Copyright (c) 2020-2021 Swift Navigation Inc.
+// Contact: Swift Navigation <dev@swiftnav.com>
+//
+// This source is subject to the license found in the file 'LICENSE' which must
+// be be distributed together with this source. All other rights reserved.
+//
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+// EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
 // Include the C bindings
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]

--- a/src/coords.rs
+++ b/src/coords.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2020-2021 Swift Navigation Inc.
+// Contact: Swift Navigation <dev@swiftnav.com>
+//
+// This source is subject to the license found in the file 'LICENSE' which must
+// be be distributed together with this source. All other rights reserved.
+//
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+// EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 //! Coordinates and conversions
 //!
 //! These four primary coordinates types are defined:

--- a/src/edc.rs
+++ b/src/edc.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2020-2021 Swift Navigation Inc.
+// Contact: Swift Navigation <dev@swiftnav.com>
+//
+// This source is subject to the license found in the file 'LICENSE' which must
+// be be distributed together with this source. All other rights reserved.
+//
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+// EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 //! Error detection code
 
 use crate::c_bindings;

--- a/src/ephemeris.rs
+++ b/src/ephemeris.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2020-2021 Swift Navigation Inc.
+// Contact: Swift Navigation <dev@swiftnav.com>
+//
+// This source is subject to the license found in the file 'LICENSE' which must
+// be be distributed together with this source. All other rights reserved.
+//
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+// EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 //! Decoding and evaluation of satellite ephemeris
 //!
 //! GNSS satellites broadcast ephemeris, values used to calculate their position

--- a/src/ionosphere.rs
+++ b/src/ionosphere.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2020-2021 Swift Navigation Inc.
+// Contact: Swift Navigation <dev@swiftnav.com>
+//
+// This source is subject to the license found in the file 'LICENSE' which must
+// be be distributed together with this source. All other rights reserved.
+//
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+// EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 //! Ionosphere delay calculation
 //!
 //! Ionospheric delays are typically modeled with the Klobuchar model. The model

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,60 @@
+//! `swiftnav-rs` is a library that implements GNSS utility functions to perform
+//! position estimations. The data used by `swiftnav-rs` typically comes from GNSS
+//! receiver chips as raw observation and ephemeris data. `swiftnav-rs` is more of
+//! a "bring your own algorithm" library, it provides a bunch of functionality that
+//! is useful when processing raw GNSS data, but it provides only limited position
+//! estimation capabilities. Each module encompasses a single set of functionality,
+//! and they are meant to be pretty self-explanatory for developers familiar with
+//! GNSS processing.
+//!
 //! GNSS systems are used to estimate the location of the receiver by determining
-//! the distance between the receiver and several satelites. The satellites send
+//! the distance between the receiver and several satellites. The satellites send
 //! out precisely timed periodic messages and the receiver measures the delay
 //! of those messages. Knowing the location of the satellites at the time of
 //! transmission and the delays of the messages the receiver is able to determine
 //! the location of itself in relation to the satellites.
 //!
-//! Libswiftnav is a library that implements GNSS utility functions to perform
-//! position estimations. The data used by libswiftnav typically comes from GNSS
-//! reciever chips as raw observation and ephemeris data.
+//! `swiftnav-rs` does not provide any functionality for communicating with
+//! receivers made by Swift Navigation, or any manufacturer. [libsbp](https://github.com/swift-nav/libsbp)
+//! is the library to use if you want to communicate with receivers using Swift
+//! Binary Protocol (SBP).
 //!
-//! Libswiftnav does not provide any functionality for communicating with Swift
-//! Navigation or any other receivers. See [libsbp](https://github.com/swift-nav/libsbp)
-//! to communicate with receivers using Swift Binary Protocol (SBP).
+//! # How to use
+//! `swiftnav-rs` is more of a "bring your own algorithm" crate, it provides a
+//! bunch of functionality that is useful when processing raw GNSS data, but it
+//! provides only limited position estimation capabilities. Each module encompasses
+//! a single set of functionality, and they are meant to be pretty self-explanatory
+//! for developers familiar with GNSS processing.
 //!
+//! ## Time
+//! Time is a very important aspect of GNSS. `swiftnav-rs` defaults to representing
+//! all times as GPS times. It provides the ability to manipulate GPS time stamps,
+//! as well as means to convert a GPS time stamp into various other time bases
+//! (GLONASS time, UTC, MJD).
+//!
+//! ## Coordinates
+//! Several different coordinate types have representations and the ability to
+//! convert between them. Earth centered earth fixed (ECEF), Latitude longitude and
+//! height (both in radians and degrees), and Azimuth and elevation coordinates are
+//! available.
+//!
+//! ## Ephemeris
+//! Decoding and evaluation of broadcast ephemeris for all major GNSS constellations
+//! is made available. You are able to calculate the satellite position at a
+//! particular point in time in several different coordinates.
+//!
+//! ## Troposphere and Ionosphere
+//! Two major sources of signal error in GNSS are the troposphere and ionosphere.
+//! `swiftnav-rs` provides the ability to decode and use the broadcast Klobuchar
+//! ionosphere model. An implementation of the UNM3m troposphere model is also
+//! provided.
+//!
+//! ## Single epoch position solver
+//! A simple least squares position solver is also included. This allows you to
+//! get an approximate position with GNSS measurements from a single point in time.
+//! It uses a least squares algorith, so no state is maintained between solves.
+//! This can be used to seed your own position estimation algorithm with a rough
+//! starting location.
 
 mod c_bindings;
 pub mod coords;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2020-2021 Swift Navigation Inc.
+// Contact: Swift Navigation <dev@swiftnav.com>
+//
+// This source is subject to the license found in the file 'LICENSE' which must
+// be be distributed together with this source. All other rights reserved.
+//
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+// EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 //! `swiftnav-rs` is a library that implements GNSS utility functions to perform
 //! position estimations. The data used by `swiftnav-rs` typically comes from GNSS
 //! receiver chips as raw observation and ephemeris data. `swiftnav-rs` is more of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,56 +7,7 @@
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
-//! `swiftnav-rs` is a library that implements GNSS utility functions to perform
-//! position estimations. The data used by `swiftnav-rs` typically comes from GNSS
-//! receiver chips as raw observation and ephemeris data. `swiftnav-rs` is more of
-//! a "bring your own algorithm" library, it provides a bunch of functionality that
-//! is useful when processing raw GNSS data, but it provides only limited position
-//! estimation capabilities. Each module encompasses a single set of functionality,
-//! and they are meant to be pretty self-explanatory for developers familiar with
-//! GNSS processing.
-//!
-//! GNSS systems are used to estimate the location of the receiver by determining
-//! the distance between the receiver and several satellites. The satellites send
-//! out precisely timed periodic messages and the receiver measures the delay
-//! of those messages. Knowing the location of the satellites at the time of
-//! transmission and the delays of the messages the receiver is able to determine
-//! the location of itself in relation to the satellites.
-//!
-//! `swiftnav-rs` does not provide any functionality for communicating with
-//! receivers made by Swift Navigation, or any manufacturer.
-//! [libsbp](https://github.com/swift-nav/libsbp) is the library to use if you
-//! want to communicate with receivers using Swift Binary Protocol (SBP).
-//!
-//! ## Time
-//! Time is a very important aspect of GNSS. `swiftnav-rs` defaults to representing
-//! all times as GPS times. It provides the ability to manipulate GPS time stamps,
-//! as well as means to convert a GPS time stamp into various other time bases
-//! (GLONASS time, UTC, MJD).
-//!
-//! ## Coordinates
-//! Several different coordinate types have representations and the ability to
-//! convert between them. Earth centered earth fixed (ECEF), Latitude longitude and
-//! height (both in radians and degrees), and Azimuth and elevation coordinates are
-//! available.
-//!
-//! ## Ephemeris
-//! Decoding and evaluation of broadcast ephemeris for all major GNSS constellations
-//! is made available. You are able to calculate the satellite position at a
-//! particular point in time in several different coordinates.
-//!
-//! ## Troposphere and Ionosphere
-//! Two major sources of signal error in GNSS are the troposphere and ionosphere.
-//! `swiftnav-rs` provides the ability to decode and use the broadcast Klobuchar
-//! ionosphere model. An implementation of the UNM3m troposphere model is also
-//! provided.
-//!
-//! ## Single epoch position solver
-//! A simple least squares position solver is also included. This allows you to
-//! get an approximate position with GNSS measurements from a single point in time.
-//! It uses a least squares algorith, so no state is maintained between solves.
-//! This can be used to seed your own position estimation algorithm with a rough
-//! starting location.
+#![doc = include_str!("../README.md")]
 
 mod c_bindings;
 pub mod coords;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,13 +19,6 @@
 //! is the library to use if you want to communicate with receivers using Swift
 //! Binary Protocol (SBP).
 //!
-//! # How to use
-//! `swiftnav-rs` is more of a "bring your own algorithm" crate, it provides a
-//! bunch of functionality that is useful when processing raw GNSS data, but it
-//! provides only limited position estimation capabilities. Each module encompasses
-//! a single set of functionality, and they are meant to be pretty self-explanatory
-//! for developers familiar with GNSS processing.
-//!
 //! ## Time
 //! Time is a very important aspect of GNSS. `swiftnav-rs` defaults to representing
 //! all times as GPS times. It provides the ability to manipulate GPS time stamps,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@
 //! the location of itself in relation to the satellites.
 //!
 //! `swiftnav-rs` does not provide any functionality for communicating with
-//! receivers made by Swift Navigation, or any manufacturer. [libsbp](https://github.com/swift-nav/libsbp)
-//! is the library to use if you want to communicate with receivers using Swift
-//! Binary Protocol (SBP).
+//! receivers made by Swift Navigation, or any manufacturer.
+//! [libsbp](https://github.com/swift-nav/libsbp) is the library to use if you
+//! want to communicate with receivers using Swift Binary Protocol (SBP).
 //!
 //! ## Time
 //! Time is a very important aspect of GNSS. `swiftnav-rs` defaults to representing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,56 @@
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
-#![doc = include_str!("../README.md")]
+//! `swiftnav-rs` is a library that implements GNSS utility functions to perform
+//! position estimations. The data used by `swiftnav-rs` typically comes from GNSS
+//! receiver chips as raw observation and ephemeris data. `swiftnav-rs` is more of
+//! a "bring your own algorithm" library, it provides a bunch of functionality that
+//! is useful when processing raw GNSS data, but it provides only limited position
+//! estimation capabilities. Each module encompasses a single set of functionality,
+//! and they are meant to be pretty self-explanatory for developers familiar with
+//! GNSS processing.
+//!
+//! GNSS systems are used to estimate the location of the receiver by determining
+//! the distance between the receiver and several satellites. The satellites send
+//! out precisely timed periodic messages and the receiver measures the delay
+//! of those messages. Knowing the location of the satellites at the time of
+//! transmission and the delays of the messages the receiver is able to determine
+//! the location of itself in relation to the satellites.
+//!
+//! `swiftnav-rs` does not provide any functionality for communicating with
+//! receivers made by Swift Navigation, or any manufacturer.
+//! [libsbp](https://github.com/swift-nav/libsbp) is the library to use if you
+//! want to communicate with receivers using Swift Binary Protocol (SBP).
+//!
+//! ## Time
+//! Time is a very important aspect of GNSS. `swiftnav-rs` defaults to representing
+//! all times as GPS times. It provides the ability to manipulate GPS time stamps,
+//! as well as means to convert a GPS time stamp into various other time bases
+//! (GLONASS time, UTC, MJD).
+//!
+//! ## Coordinates
+//! Several different coordinate types have representations and the ability to
+//! convert between them. Earth centered earth fixed (ECEF), Latitude longitude and
+//! height (both in radians and degrees), and Azimuth and elevation coordinates are
+//! available.
+//!
+//! ## Ephemeris
+//! Decoding and evaluation of broadcast ephemeris for all major GNSS constellations
+//! is made available. You are able to calculate the satellite position at a
+//! particular point in time in several different coordinates.
+//!
+//! ## Troposphere and Ionosphere
+//! Two major sources of signal error in GNSS are the troposphere and ionosphere.
+//! `swiftnav-rs` provides the ability to decode and use the broadcast Klobuchar
+//! ionosphere model. An implementation of the UNM3m troposphere model is also
+//! provided.
+//!
+//! ## Single epoch position solver
+//! A simple least squares position solver is also included. This allows you to
+//! get an approximate position with GNSS measurements from a single point in time.
+//! It uses a least squares algorith, so no state is maintained between solves.
+//! This can be used to seed your own position estimation algorithm with a rough
+//! starting location.
 
 mod c_bindings;
 pub mod coords;

--- a/src/navmeas.rs
+++ b/src/navmeas.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2020-2021 Swift Navigation Inc.
+// Contact: Swift Navigation <dev@swiftnav.com>
+//
+// This source is subject to the license found in the file 'LICENSE' which must
+// be be distributed together with this source. All other rights reserved.
+//
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+// EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 //! Raw GNSS measurement representation
 //!
 //! Raw measurements of GNSS signals have several aspects to them, from the time

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2020-2021 Swift Navigation Inc.
+// Contact: Swift Navigation <dev@swiftnav.com>
+//
+// This source is subject to the license found in the file 'LICENSE' which must
+// be be distributed together with this source. All other rights reserved.
+//
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+// EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 //! Signal identifiers
 //!
 //! Signals are specific to a satellite and code combination. A satellite is

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2020-2021 Swift Navigation Inc.
+// Contact: Swift Navigation <dev@swiftnav.com>
+//
+// This source is subject to the license found in the file 'LICENSE' which must
+// be be distributed together with this source. All other rights reserved.
+//
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+// EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 //! Single epoch PVT solver
 //!
 //! Several [raw measurements](crate::navmeas::NavigationMeasurement) from the

--- a/src/troposphere.rs
+++ b/src/troposphere.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2020-2021 Swift Navigation Inc.
+// Contact: Swift Navigation <dev@swiftnav.com>
+//
+// This source is subject to the license found in the file 'LICENSE' which must
+// be be distributed together with this source. All other rights reserved.
+//
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+// EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 //! Troposphere delay calculation
 //!
 //! Tropospheric delays are typically modeled with the UNM3m model. The model


### PR DESCRIPTION
Cleaned up the formatting and spelling in the README. Also added some more introductory information to the crate docs. `swiftnav-rs` is never going to be a "plug and play" positioning library, but I felt like it could do with a little bit of a prelude explaining what functionality it provides and the type of developer that might be interested in using it.