### PR TITLE
Update code to be more inline with the Rust API style

### DIFF
--- a/src/coords.rs
+++ b/src/coords.rs
@@ -291,7 +291,7 @@ impl ECEF {
     /// First the vector between the points is converted into the local North, East,
     /// Down frame of the reference point. Then we can directly calculate the
     /// azimuth and elevation.
-    pub fn get_azel_of(&self, point: &ECEF) -> AzimuthElevation {
+    pub fn azel_of(&self, point: &ECEF) -> AzimuthElevation {
         let mut azel = AzimuthElevation::new(0.0, 0.0);
         unsafe {
             c_bindings::wgsecef2azel(point.as_ptr(), self.as_ptr(), &mut azel.az, &mut azel.el)

--- a/src/ephemeris.rs
+++ b/src/ephemeris.rs
@@ -302,7 +302,7 @@ impl Ephemeris {
     /// Calculate satellite position, velocity and clock offset from ephemeris.
     pub fn calc_satellite_state(&self, t: GpsTime) -> Result<SatelliteState, InvalidEphemeris> {
         // First make sure the ephemeris is valid at `t`, and bail early if it isn't
-        self.get_detailed_status(t).to_result()?;
+        self.detailed_status(t).to_result()?;
 
         let mut sat = SatelliteState {
             pos: ECEF::default(),
@@ -338,7 +338,7 @@ impl Ephemeris {
         pos: ECEF,
     ) -> Result<AzimuthElevation, InvalidEphemeris> {
         // First make sure the ephemeris is valid at `t`, and bail early if it isn't
-        self.get_detailed_status(t).to_result()?;
+        self.detailed_status(t).to_result()?;
 
         let mut sat = AzimuthElevation::default();
 
@@ -367,7 +367,7 @@ impl Ephemeris {
         vel: ECEF,
     ) -> Result<f64, InvalidEphemeris> {
         // First make sure the ephemeris is valid at `t`, and bail early if it isn't
-        self.get_detailed_status(t).to_result()?;
+        self.detailed_status(t).to_result()?;
 
         let mut doppler = 0.0;
 
@@ -386,17 +386,17 @@ impl Ephemeris {
         Ok(doppler)
     }
 
-    pub fn get_sid(&self) -> Result<GnssSignal, InvalidGnssSignal> {
+    pub fn sid(&self) -> Result<GnssSignal, InvalidGnssSignal> {
         GnssSignal::from_gnss_signal_t(self.0.sid)
     }
 
     /// Gets the status of an ephemeris - is the ephemeris invalid, unhealthy,
     /// or has some other condition which makes it unusable?
-    pub fn get_status(&self) -> Status {
+    pub fn status(&self) -> Status {
         Status::from_ephemeris_status_t(unsafe { c_bindings::get_ephemeris_status_t(&self.0) })
     }
 
-    pub fn get_detailed_status(&self, t: GpsTime) -> Status {
+    pub fn detailed_status(&self, t: GpsTime) -> Status {
         Status::from_ephemeris_status_t(unsafe {
             c_bindings::ephemeris_valid_detailed(&self.0, t.c_ptr())
         })

--- a/src/navmeas.rs
+++ b/src/navmeas.rs
@@ -46,7 +46,7 @@ impl NavigationMeasurement {
     }
 
     /// Gets the pseudorange measurement, if a valid one has been set
-    pub fn get_pseudorange(&self) -> Option<f64> {
+    pub fn pseudorange(&self) -> Option<f64> {
         if self.0.flags & NAV_MEAS_FLAG_CODE_VALID != 0 {
             Some(self.0.pseudorange)
         } else {
@@ -68,7 +68,7 @@ impl NavigationMeasurement {
     }
 
     /// Gets the measured doppler measurement, if a valid one has been set
-    pub fn get_measured_doppler(&self) -> Option<f64> {
+    pub fn measured_doppler(&self) -> Option<f64> {
         if self.0.flags & NAV_MEAS_FLAG_MEAS_DOPPLER_VALID != 0 {
             Some(self.0.measured_doppler)
         } else {
@@ -101,7 +101,7 @@ impl NavigationMeasurement {
     }
 
     /// Gets the signal CN0 measurement, if a valid one has been set
-    pub fn get_cn0(&self) -> Option<f64> {
+    pub fn cn0(&self) -> Option<f64> {
         if self.0.flags & NAV_MEAS_FLAG_CN0_VALID != 0 {
             Some(self.0.cn0)
         } else {
@@ -121,7 +121,7 @@ impl NavigationMeasurement {
         self.0.lock_time = value.as_secs_f64();
     }
 
-    pub fn get_lock_time(&self) -> Duration {
+    pub fn lock_time(&self) -> Duration {
         Duration::from_secs_f64(self.0.lock_time)
     }
 
@@ -130,7 +130,7 @@ impl NavigationMeasurement {
         self.0.sid = value.to_gnss_signal_t();
     }
 
-    pub fn get_sid(&self) -> GnssSignal {
+    pub fn sid(&self) -> GnssSignal {
         GnssSignal::from_gnss_signal_t(self.0.sid).unwrap()
     }
 
@@ -139,7 +139,7 @@ impl NavigationMeasurement {
         self.0.flags = flags;
     }
 
-    pub fn get_flags(&self) -> u16 {
+    pub fn flags(&self) -> u16 {
         self.0.flags
     }
 

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -59,14 +59,12 @@ impl Constellation {
             c_bindings::constellation_e_CONSTELLATION_BDS => Ok(Constellation::Bds),
             c_bindings::constellation_e_CONSTELLATION_QZS => Ok(Constellation::Qzs),
             c_bindings::constellation_e_CONSTELLATION_GAL => Ok(Constellation::Gal),
-            c_bindings::constellation_e_CONSTELLATION_INVALID
-            | c_bindings::constellation_e_CONSTELLATION_COUNT
-            | _ => Err(InvalidConstellation(value)),
+            _ => Err(InvalidConstellation(value)),
         }
     }
 
-    pub(crate) fn to_constellation_t(&self) -> c_bindings::constellation_t {
-        match *self {
+    pub(crate) fn to_constellation_t(self) -> c_bindings::constellation_t {
+        match self {
             Constellation::Gps => c_bindings::constellation_e_CONSTELLATION_GPS,
             Constellation::Sbas => c_bindings::constellation_e_CONSTELLATION_SBAS,
             Constellation::Glo => c_bindings::constellation_e_CONSTELLATION_GLO,
@@ -278,14 +276,14 @@ impl Code {
             c_bindings::code_e_CODE_AUX_GAL => Ok(Code::AuxGal),
             c_bindings::code_e_CODE_AUX_QZS => Ok(Code::AuxQzs),
             c_bindings::code_e_CODE_AUX_BDS => Ok(Code::AuxBds),
-            c_bindings::code_e_CODE_INVALID | c_bindings::code_e_CODE_COUNT | _ => {
+            _ => {
                 Err(InvalidCode(value))
             }
         }
     }
 
-    pub(crate) fn to_code_t(&self) -> c_bindings::code_t {
-        match *self {
+    pub(crate) fn to_code_t(self) -> c_bindings::code_t {
+        match self {
             Code::GpsL1ca => c_bindings::code_e_CODE_GPS_L1CA,
             Code::GpsL2cm => c_bindings::code_e_CODE_GPS_L2CM,
             Code::SbasL1ca => c_bindings::code_e_CODE_SBAS_L1CA,
@@ -354,7 +352,7 @@ impl Code {
     }
 
     /// Attempts to make a `Code` from a string
-    pub fn from_str(s: &ffi::CStr) -> Result<Code, InvalidCode> {
+    pub fn from_c_str(s: &ffi::CStr) -> Result<Code, InvalidCode> {
         Self::from_code_t(unsafe { c_bindings::code_string_to_enum(s.as_ptr()) })
     }
 
@@ -468,15 +466,15 @@ impl GnssSignal {
         GnssSignal::new(sid.sat, Code::from_code_t(sid.code)?)
     }
 
-    pub(crate) fn to_gnss_signal_t(&self) -> c_bindings::gnss_signal_t {
+    pub(crate) fn to_gnss_signal_t(self) -> c_bindings::gnss_signal_t {
         self.0
     }
 
-    pub fn get_sat(&self) -> u16 {
+    pub fn sat(&self) -> u16 {
         self.0.sat
     }
 
-    pub fn get_code(&self) -> Code {
+    pub fn code(&self) -> Code {
         Code::from_code_t(self.0.code).unwrap()
     }
 

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -187,8 +187,8 @@ pub enum ProcessingStrategy {
 }
 
 impl ProcessingStrategy {
-    pub(crate) fn to_processing_strategy_t(&self) -> c_bindings::processing_strategy_t {
-        match *self {
+    pub(crate) fn to_processing_strategy_t(self) -> c_bindings::processing_strategy_t {
+        match self {
             ProcessingStrategy::GpsOnly => c_bindings::processing_strategy_t_GPS_ONLY,
             ProcessingStrategy::AllConstellations => {
                 c_bindings::processing_strategy_t_ALL_CONSTELLATIONS
@@ -299,12 +299,12 @@ impl SidSet {
     }
 
     /// Gets the number of satellites in the set
-    pub fn get_sat_count(&self) -> u32 {
+    pub fn sat_count(&self) -> u32 {
         unsafe { c_bindings::sid_set_get_sat_count(&self.0) }
     }
 
     /// Gets the number of signals in the set
-    pub fn get_sig_count(&self) -> u32 {
+    pub fn sig_count(&self) -> u32 {
         unsafe { c_bindings::sid_set_get_sig_count(&self.0) }
     }
 
@@ -761,9 +761,9 @@ mod tests {
          * geometry */
 
         let mut nm1_broken = make_nm1();
-        nm1_broken.set_pseudorange(nm1_broken.get_pseudorange().unwrap() + 5e8);
+        nm1_broken.set_pseudorange(nm1_broken.pseudorange().unwrap() + 5e8);
         let mut nm2_broken = make_nm2();
-        nm2_broken.set_pseudorange(nm2_broken.get_pseudorange().unwrap() - 2e7);
+        nm2_broken.set_pseudorange(nm2_broken.pseudorange().unwrap() - 2e7);
 
         let nms = [
             nm1_broken,
@@ -1002,9 +1002,9 @@ mod tests {
 
         /* add a common bias of 120 m to the L2CM measurements */
         let mut nm10_bias = make_nm10();
-        nm10_bias.set_pseudorange(nm10_bias.get_pseudorange().unwrap() + 120.);
+        nm10_bias.set_pseudorange(nm10_bias.pseudorange().unwrap() + 120.);
         let mut nm11_bias = make_nm11();
-        nm11_bias.set_pseudorange(nm11_bias.get_pseudorange().unwrap() + 120.);
+        nm11_bias.set_pseudorange(nm11_bias.pseudorange().unwrap() + 120.);
 
         /* healthy measurements, with bias on L2 */
         let nms = [
@@ -1050,7 +1050,7 @@ mod tests {
         );
 
         /* add outlier to one of the L2 measurements  */
-        nm11_bias.set_pseudorange(nm11_bias.get_pseudorange().unwrap() + 1000.);
+        nm11_bias.set_pseudorange(nm11_bias.pseudorange().unwrap() + 1000.);
         let nms = [
             make_nm2(),
             make_nm3(),


### PR DESCRIPTION
As mentioned in https://github.com/swift-nav/swiftnav-rs/pull/63#discussion_r680417714 we have several inconsistencies in the function naming style and a few clippy warnings to clean up.

- Remove `get_` prefix on getter functions
- Clean up some pattern matching logic per `clippy` advice
- Make `to_` conversion functions consume `self` to match common convention 