### PR TITLE
Remove cpp tests from the default features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,5 @@ bindgen = "0.59"
 cmake = "0.1"
 
 [features]
-default = ["testcpp"]
 testcpp = []
 chrono-support = ["chrono"]

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,8 @@ fn main() {
     if !cfg!(feature = "testcpp") {
         cmake
             .define("libswiftnav_ENABLE_TESTS", "OFF")
-            .define("libswiftnav_ENABLE_TEST_LIBS", "OFF");
+            .define("libswiftnav_ENABLE_TEST_LIBS", "OFF")
+            .define("disable_tests", "OFF");
     }
 
     cmake

--- a/build.rs
+++ b/build.rs
@@ -10,8 +10,7 @@ fn main() {
     if !cfg!(feature = "testcpp") {
         cmake
             .define("libswiftnav_ENABLE_TESTS", "OFF")
-            .define("libswiftnav_ENABLE_TEST_LIBS", "OFF")
-            .define("disable_tests", "OFF");
+            .define("libswiftnav_ENABLE_TEST_LIBS", "OFF");
     }
 
     cmake


### PR DESCRIPTION
While we should probably be running the C/C++ tests in the CI for this crate, I don't think it makes much sense to be running them by default in other crates that use this. Our CI should be building with `--all-features` already so the tests will be built and run.