### PR TITLE
swiftnav-sys: fixes compatibility with CentOS

### DIFF
--- a/swiftnav-sys/build.rs
+++ b/swiftnav-sys/build.rs
@@ -23,6 +23,7 @@ fn main() {
     let dst = cmake.build();
 
     println!("cargo:rustc-link-search=native={}/lib/", dst.display());
+    println!("cargo:rustc-link-search=native={}/lib64/", dst.display());
     println!("cargo:rustc-link-lib=static=swiftnav");
 
     let include_args = vec![


### PR DESCRIPTION
On CentOS libswiftnav installs into `lib64` -- so add `lib64` as a directory that we search for the library.

---

Tested on a CentOS 7 VM.  Installed clang 9 from here:
- https://releases.llvm.org/download.html#9.0.0 (`SuSE Linux Enterprise Server 11SP3 x86_64` variant)

CMake from pre-built binary: https://cmake.org/download/

Rust and cargo from https://rustup.rs