### PR TITLE
crates.io release cleanup

### DIFF
--- a/swiftnav/Cargo.toml
+++ b/swiftnav/Cargo.toml
@@ -11,6 +11,3 @@ license = "LGPL-3.0"
 [dependencies]
 chrono = { version = "0.4", optional = true }
 swiftnav-sys = { version = "^0.6.2-alpha.0", path = "../swiftnav-sys/" }
-
-[features]
-chrono-support = ["chrono"]

--- a/swiftnav/src/coords.rs
+++ b/swiftnav/src/coords.rs
@@ -10,10 +10,10 @@
 //! Coordinates and conversions
 //!
 //! These four primary coordinates types are defined:
-//!  * [LLH](LLH) - Geodetic coordinates, Latitude Lontitude Height
-//!  * [ECEF](ECEF) - Cartesian coordinates, Earth Centered, Earth Fixed
-//!  * NED - Relative direction coordinates, North East Down
-//!  * [AzEl](AzEl) - Relative direction coordinates, Azimith Elevation
+//!  * [LLHDegrees]/[LLHRadians] - Geodetic coordinates, Latitude Lontitude Height
+//!  * [ECEF] - Cartesian coordinates, Earth Centered, Earth Fixed
+//!  * [NED] - Relative direction coordinates, North East Down
+//!  * [AzimuthElevation] - Relative direction coordinates, Azimith Elevation
 //!
 //! --------
 //! Conversion from geodetic coordinates latitude, longitude and height

--- a/swiftnav/src/ionosphere.rs
+++ b/swiftnav/src/ionosphere.rs
@@ -100,13 +100,13 @@ impl Ionosphere {
     /// Calculate ionospheric delay using Klobuchar model.
     ///
     /// \param t_gps GPS time at which to calculate the ionospheric delay
-    /// \param lat_u Latitude of the receiver [rad]
-    /// \param lon_u Longitude of the receiver [rad]
-    /// \param a Azimuth of the satellite, clockwise positive from North [rad]
-    /// \param e Elevation of the satellite [rad]
+    /// \param lat_u Latitude of the receiver \[rad\]
+    /// \param lon_u Longitude of the receiver \[rad\]
+    /// \param a Azimuth of the satellite, clockwise positive from North \[rad\]
+    /// \param e Elevation of the satellite \[rad\]
     /// \param i Ionosphere parameters struct from GPS NAV data
     ///
-    /// \return Ionospheric delay distance for GPS L1 frequency [m]
+    /// \return Ionospheric delay distance for GPS L1 frequency \[m\]
     pub fn calc_delay(&self, t: &GpsTime, lat_u: f64, lon_u: f64, a: f64, e: f64) -> f64 {
         unsafe { swiftnav_sys::calc_ionosphere(t.c_ptr(), lat_u, lon_u, a, e, &self.0) }
     }

--- a/swiftnav/src/time.rs
+++ b/swiftnav/src/time.rs
@@ -742,7 +742,7 @@ impl From<MJD> for UtcTime {
     }
 }
 
-#[cfg(feature = "chrono-support")]
+#[cfg(feature = "chrono")]
 impl From<UtcTime> for chrono::DateTime<chrono::offset::Utc> {
     fn from(utc: UtcTime) -> chrono::DateTime<chrono::offset::Utc> {
         use chrono::prelude::*;
@@ -766,7 +766,7 @@ impl From<UtcTime> for chrono::DateTime<chrono::offset::Utc> {
     }
 }
 
-#[cfg(feature = "chrono-support")]
+#[cfg(feature = "chrono")]
 impl<Tz: chrono::offset::TimeZone> From<chrono::DateTime<Tz>> for UtcTime {
     fn from(chrono: chrono::DateTime<Tz>) -> UtcTime {
         use chrono::prelude::*;

--- a/swiftnav/src/time.rs
+++ b/swiftnav/src/time.rs
@@ -8,7 +8,7 @@
 //! midnight on Sunday.
 //!
 //! [`GpsTime`] is the primary representation used in swiftnav-rs. Other time bases
-//! are available, such as [`Utctime`], [`GalTime`], [`BdsTime`], and [`GloTime`]
+//! are available, such as [`UtcTime`], [`GalTime`], [`BdsTime`], and [`GloTime`]
 //! along with conversions for all of these to and from [`GpsTime`].
 //! Not all functionality is available in these other representations, so it's
 //! intended that all times are to converted to [`GpsTime`] before use with
@@ -603,15 +603,15 @@ impl UtcParams {
         })
     }
 
-    /// Modulo 1 sec offset from GPS to UTC [s]
+    /// Modulo 1 sec offset from GPS to UTC \[s\]
     pub fn a0(&self) -> f64 {
         self.0.a0
     }
-    /// Drift of time offset from GPS to UTC [s/s]
+    /// Drift of time offset from GPS to UTC \[s/s\]
     pub fn a1(&self) -> f64 {
         self.0.a1
     }
-    /// Drift rate correction from GPS to UTC [s/s]
+    /// Drift rate correction from GPS to UTC \[s/s\]
     pub fn a2(&self) -> f64 {
         self.0.a2
     }
@@ -623,11 +623,11 @@ impl UtcParams {
     pub fn t_lse(&self) -> GpsTime {
         GpsTime(self.0.t_lse)
     }
-    /// Leap second delta from GPS to UTC before LS event [s]
+    /// Leap second delta from GPS to UTC before LS event \[s\]
     pub fn dt_ls(&self) -> i8 {
         self.0.dt_ls
     }
-    /// Leap second delta from GPS to UTC after LS event [s]
+    /// Leap second delta from GPS to UTC after LS event \[s\]
     pub fn dt_lsf(&self) -> i8 {
         self.0.dt_lsf
     }


### PR DESCRIPTION
- Rename `chrono-support` feature to `chrono`
- Escapes some braces in doc comments/fixes a few links