### PR TITLE
Remove step to manually install LLVM on windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Set env vars for Windows
         run: |
-          echo "LIBCLANG_PATH='C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/lib'" >> $GITHUB_ENV
+          echo "LIBCLANG_PATH='C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/lib/'" >> $GITHUB_ENV
           ls "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/lib"
           tree "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/"
         if: matrix.os == 'windows-2019'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,13 @@ jobs:
         run: |
           sudo apt-get install musl-tools
           sudo ln -s /usr/bin/musl-gcc /usr/bin/musl-g++
+          
+      - name: Set up Clang
+        uses: egor-tensin/setup-clang@v1
+        if: matrix.os == 'windows-2019'
+        with:
+          version: "10.0"
+          platform: x64
 
       - name: Install rust ${{ matrix.binary_target }}
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,9 +40,12 @@ jobs:
           toolchain: stable-${{ matrix.binary_target }}
           profile: minimal
 
+      - name: Set env vars for Windows
+        run: |
+          echo "LIBCLANG_PATH=${LIBCLANG_PATH_WIN}" >> $GITHUB_ENV
+        if: matrix.os == 'windows-2019'
+
       - uses: actions-rs/cargo@v1
-        env:
-          LIBCLANG_PATH: ${{ env.LIBCLANG_PATH_WIN }}
         with:
           command: make
           args: --makefile ci-makefile.toml --no-workspace workspace-ci-flow

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Set env vars for Windows
         run: |
-          echo "LIBCLANG_PATH='C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/bin'" >> $GITHUB_ENV
+          echo "LIBCLANG_PATH='C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/lib'" >> $GITHUB_ENV
         if: matrix.os == 'windows-2019'
 
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,8 @@ jobs:
       - name: Set env vars for Windows
         run: |
           echo "LIBCLANG_PATH='C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/lib'" >> $GITHUB_ENV
-          ls C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/lib
-          treeC:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/
+          ls "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/lib"
+          tree "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/"
         if: matrix.os == 'windows-2019'
 
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         with:
           version: "10.0"
+          directory: ${{ runner.temp }}/llvm-10.0/
 
       - name: Install rust ${{ matrix.binary_target }}
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "master"
+env:
+  LIBCLANG_PATH_WIN: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/bin"
 jobs:
   ci:
     name: Format, lint, and test
@@ -31,13 +33,6 @@ jobs:
         run: |
           sudo apt-get install musl-tools
           sudo ln -s /usr/bin/musl-gcc /usr/bin/musl-g++
-          
-      - name: Set up Clang
-        uses: egor-tensin/setup-clang@v1
-        if: matrix.os == 'windows-2019'
-        with:
-          version: "10.0"
-          platform: x64
 
       - name: Install rust ${{ matrix.binary_target }}
         uses: actions-rs/toolchain@v1
@@ -46,6 +41,8 @@ jobs:
           profile: minimal
 
       - uses: actions-rs/cargo@v1
+        env:
+          LIBCLANG_PATH: ${{ env.LIBCLANG_PATH_WIN }}
         with:
           command: make
           args: --makefile ci-makefile.toml --no-workspace workspace-ci-flow

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
             binary_target: x86_64-unknown-linux-gnu
           - os: macos-10.15
             binary_target: x86_64-apple-darwin
-          - os: windows-2019
+          - os: windows-latest
             binary_target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,13 +38,6 @@ jobs:
           toolchain: stable-${{ matrix.binary_target }}
           profile: minimal
 
-      - name: Set env vars for Windows
-        run: |
-          echo "LIBCLANG_PATH='C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/lib/'" >> $GITHUB_ENV
-          ls "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/lib"
-          tree "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/"
-        if: matrix.os == 'windows-2019'
-
       - uses: actions-rs/cargo@v1
         with:
           command: make

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - "master"
-env:
-  LIBCLANG_PATH_WIN: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/bin"
 jobs:
   ci:
     name: Format, lint, and test
@@ -42,7 +40,7 @@ jobs:
 
       - name: Set env vars for Windows
         run: |
-          echo "LIBCLANG_PATH=${LIBCLANG_PATH_WIN}" >> $GITHUB_ENV
+          echo "LIBCLANG_PATH='C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/bin'" >> $GITHUB_ENV
         if: matrix.os == 'windows-2019'
 
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,12 @@ jobs:
           sudo apt-get install musl-tools
           sudo ln -s /usr/bin/musl-gcc /usr/bin/musl-g++
 
+      - name: Install LLVM and Clang # required for bindgen on Windows
+        uses: KyleMayes/install-llvm-action@v1
+        if: matrix.os == 'windows-latest'
+        with:
+          version: "10.0"
+
       - name: Install rust ${{ matrix.binary_target }}
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,12 +32,6 @@ jobs:
           sudo apt-get install musl-tools
           sudo ln -s /usr/bin/musl-gcc /usr/bin/musl-g++
 
-      - name: Install LLVM and Clang # required for bindgen on Windows
-        uses: KyleMayes/install-llvm-action@v1
-        if: matrix.os == 'windows-2019'
-        with:
-          version: "10.0"
-
       - name: Install rust ${{ matrix.binary_target }}
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,8 @@ jobs:
       - name: Set env vars for Windows
         run: |
           echo "LIBCLANG_PATH='C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/lib'" >> $GITHUB_ENV
+          ls C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/lib
+          treeC:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/
         if: matrix.os == 'windows-2019'
 
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
While building #76 I ran into issues with the Windows build hanging. It looks like LLVM is now installed by default, so we don't need to manually install it anymore.

Problematic build: https://github.com/swift-nav/swiftnav-rs/runs/3804887134?check_suite_focus=true#step:5:26