### PR TITLE
Add wrappers for converting UTC times into GPS times

### DIFF
--- a/swiftnav-sys/build.rs
+++ b/swiftnav-sys/build.rs
@@ -73,6 +73,7 @@ fn main() {
         .allowlist_function("add_secs")
         .allowlist_function("decode_utc_parameters")
         .allowlist_function("gps2utc")
+        .allowlist_function("utc2gps")
         .allowlist_function("date2mjd")
         .allowlist_function("mjd2utc")
         .allowlist_function("utc2mjd")


### PR DESCRIPTION
With the latest update to `libswiftnav` a function to convert UTC times into GPS has been added. This exposes this functionality in the Rust wrapper.