### PR TITLE
Add total_cmp function 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,6 @@
+---
 name: CI
-on:
+"on":
   pull_request:
   push:
     branches:
@@ -11,15 +12,34 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-18.04
+          # Ubuntus
+          - os: ubuntu-latest
             binary_target: x86_64-unknown-linux-musl
             needs_musl: true
-          - os: ubuntu-18.04
+            toolchain: stable
+          - os: ubuntu-20.04
             binary_target: x86_64-unknown-linux-gnu
-          - os: macos-10.15
+            toolchain: stable
+
+          # MacOS
+          - os: macos-11
             binary_target: x86_64-apple-darwin
+            toolchain: stable
+
+          # Windows
           - os: windows-latest
             binary_target: x86_64-pc-windows-msvc
+            toolchain: stable
+
+          # Nightly Rust
+          - os: ubuntu-latest
+            binary_target: x86_64-unknown-linux-gnu
+            toolchain: nightly
+
+          # MSRV
+          - os: ubuntu-latest
+            binary_target: x86_64-unknown-linux-gnu
+            toolchain: 1.57.0
     steps:
       - uses: actions/checkout@v2
         with:
@@ -32,7 +52,8 @@ jobs:
           sudo apt-get install musl-tools
           sudo ln -s /usr/bin/musl-gcc /usr/bin/musl-g++
 
-      - name: Install LLVM and Clang # required for bindgen on Windows
+      # Required for bindgen on Windows
+      - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1
         if: matrix.os == 'windows-latest'
         with:
@@ -49,10 +70,10 @@ jobs:
       - name: Install rust ${{ matrix.binary_target }}
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable-${{ matrix.binary_target }}
+          toolchain: ${{ matrix.toolchain }}-${{ matrix.binary_target }}
           profile: minimal
 
       - uses: actions-rs/cargo@v1
         with:
           command: make
-          args: --makefile ci-makefile.toml --no-workspace workspace-ci-flow
+          args: --no-workspace workspace-ci-flow

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
           # MSRV
           - os: ubuntu-latest
             binary_target: x86_64-unknown-linux-gnu
-            toolchain: 1.57.0
+            toolchain: 1.56.1
     steps:
       - uses: actions/checkout@v2
         with:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -4,6 +4,7 @@ CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 CARGO_MAKE_RUN_CLIPPY = true
 CARGO_MAKE_CLIPPY_ARGS = "--all-features -- -D warnings"
 CARGO_MAKE_RUN_CHECK_FORMAT = true
+CARGO_MAKE_CARGO_VERBOSE_FLAGS = "-vv"
 RUSTFLAGS="-D warnings"
 
 [tasks.check-format-ci-flow]

--- a/swiftnav-sys/Cargo.toml
+++ b/swiftnav-sys/Cargo.toml
@@ -7,6 +7,7 @@ description = "FFI bindings for libswiftnav"
 readme = "../README.md"
 repository = "https://github.com/swift-nav/swiftnav-rs"
 license = "LGPL-3.0"
+rust-version = "1.56.1"
 
 [build-dependencies]
 bindgen = "0.59"

--- a/swiftnav/Cargo.toml
+++ b/swiftnav/Cargo.toml
@@ -9,5 +9,6 @@ repository = "https://github.com/swift-nav/swiftnav-rs"
 license = "LGPL-3.0"
 
 [dependencies]
+rustversion = "1.0"
 chrono = { version = "0.4", optional = true }
 swiftnav-sys = { version = "^0.8.0", path = "../swiftnav-sys/" }

--- a/swiftnav/Cargo.toml
+++ b/swiftnav/Cargo.toml
@@ -7,6 +7,7 @@ description = "GNSS positioning and related utilities"
 readme = "../README.md"
 repository = "https://github.com/swift-nav/swiftnav-rs"
 license = "LGPL-3.0"
+rust-version = "1.56.1"
 
 [dependencies]
 rustversion = "1.0"

--- a/swiftnav/src/time.rs
+++ b/swiftnav/src/time.rs
@@ -301,8 +301,20 @@ impl GpsTime {
         GloTime(unsafe { swiftnav_sys::gps2glo(self.c_ptr(), std::ptr::null()) })
     }
 
+    /// Compare between itself and other GpsTime
+    /// Checks whether week number is same which then mirrors [`f64::total_cmp()`]
     pub fn total_cmp(&self, other: &GpsTime) -> Ordering {
-        self.tow().total_cmp(&other.tow())
+        if self.wn() != other.wn() {
+            self.wn().cmp(&other.wn())
+        } else {
+            let mut left = self.tow().to_bits() as i64;
+            let mut right = other.tow().to_bits() as i64;
+
+            left ^= (((left >> 63) as u64) >> 1) as i64;
+            right ^= (((right >> 63) as u64) >> 1) as i64;
+
+            left.cmp(&right)
+        }
     }
 }
 

--- a/swiftnav/src/time.rs
+++ b/swiftnav/src/time.rs
@@ -302,9 +302,7 @@ impl GpsTime {
     }
 
     /// Compare between itself and other GpsTime
-    /// Checks whether week number is same which then mirrors [`f64::total_cmp()`]
-    ///
-    /// See: [`https://github.com/rust-lang/rust/blob/481db40311cdd241ae4d33f34f2f75732e44d8e8/library/core/src/num/f64.rs#L1228`]
+    /// Checks whether week number is same which then mirrors [`https://github.com/rust-lang/rust/blob/481db40311cdd241ae4d33f34f2f75732e44d8e8/library/core/src/num/f64.rs#L1228`](f64::total_cmp())
     pub fn total_cmp(&self, other: &GpsTime) -> Ordering {
         if self.wn() != other.wn() {
             self.wn().cmp(&other.wn())

--- a/swiftnav/src/time.rs
+++ b/swiftnav/src/time.rs
@@ -44,6 +44,7 @@
 //! [`UtcParams`] object to handle the leap second conversion and one which doesn't
 //! take a [`UtcParams`] object but has `_hardcoded` appended to the function name.
 
+use std::cmp::Ordering;
 use std::error::Error;
 use std::fmt;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
@@ -298,6 +299,16 @@ impl GpsTime {
         assert!(self.is_valid());
         assert!(self >= GLO_TIME_START);
         GloTime(unsafe { swiftnav_sys::gps2glo(self.c_ptr(), std::ptr::null()) })
+    }
+
+    pub fn total_cmp(&self, other: &GpsTime) -> Ordering {
+        if self == other {
+            Ordering::Equal
+        } else if self > other {
+            Ordering::Greater
+        } else {
+            Ordering::Less
+        }
     }
 }
 

--- a/swiftnav/src/time.rs
+++ b/swiftnav/src/time.rs
@@ -44,7 +44,6 @@
 //! [`UtcParams`] object to handle the leap second conversion and one which doesn't
 //! take a [`UtcParams`] object but has `_hardcoded` appended to the function name.
 
-use std::cmp::Ordering;
 use std::error::Error;
 use std::fmt;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
@@ -301,20 +300,16 @@ impl GpsTime {
         GloTime(unsafe { swiftnav_sys::gps2glo(self.c_ptr(), std::ptr::null()) })
     }
 
+    #[rustversion::since(1.62)]
     /// Compare between itself and other GpsTime
-    /// Checks whether week number is same which then mirrors [`https://github.com/rust-lang/rust/blob/481db40311cdd241ae4d33f34f2f75732e44d8e8/library/core/src/num/f64.rs#L1228`](f64::total_cmp())
-    pub fn total_cmp(&self, other: &GpsTime) -> Ordering {
+    /// Checks whether week number is same which then mirrors
+    /// [f64::total_cmp()](https://doc.rust-lang.org/std/primitive.f64.html#method.total_cmp)
+    pub fn total_cmp(&self, other: &GpsTime) -> std::cmp::Ordering {
         if self.wn() != other.wn() {
             self.wn().cmp(&other.wn())
         } else {
-            //TODO: replace with f64::total_cmp
-            let mut left = self.tow().to_bits() as i64;
-            let mut right = other.tow().to_bits() as i64;
-
-            left ^= (((left >> 63) as u64) >> 1) as i64;
-            right ^= (((right >> 63) as u64) >> 1) as i64;
-
-            left.cmp(&right)
+            let other = other.tow();
+            self.tow().total_cmp(&other)
         }
     }
 }
@@ -920,6 +915,26 @@ mod tests {
         assert!(t3 >= t2);
         assert!(t3 <= t3);
         assert!(t3 >= t3);
+    }
+
+    #[rustversion::since(1.62)]
+    #[test]
+    fn total_order() {
+        use std::cmp::Ordering;
+
+        let t1 = GpsTime::new(10, 234.566).unwrap();
+        let t2 = GpsTime::new(10, 234.567).unwrap();
+        let t3 = GpsTime::new(10, 234.568).unwrap();
+
+        assert!(t1.total_cmp(&t2) == Ordering::Less);
+        assert!(t2.total_cmp(&t3) == Ordering::Less);
+        assert!(t1.total_cmp(&t3) == Ordering::Less);
+
+        assert!(t2.total_cmp(&t1) == Ordering::Greater);
+        assert!(t3.total_cmp(&t2) == Ordering::Greater);
+        assert!(t3.total_cmp(&t1) == Ordering::Greater);
+
+        assert!(t1.total_cmp(&t1) == Ordering::Equal);
     }
 
     #[test]

--- a/swiftnav/src/time.rs
+++ b/swiftnav/src/time.rs
@@ -303,10 +303,13 @@ impl GpsTime {
 
     /// Compare between itself and other GpsTime
     /// Checks whether week number is same which then mirrors [`f64::total_cmp()`]
+    ///
+    /// See: [`https://github.com/rust-lang/rust/blob/481db40311cdd241ae4d33f34f2f75732e44d8e8/library/core/src/num/f64.rs#L1228`]
     pub fn total_cmp(&self, other: &GpsTime) -> Ordering {
         if self.wn() != other.wn() {
             self.wn().cmp(&other.wn())
         } else {
+            //TODO: replace with f64::total_cmp
             let mut left = self.tow().to_bits() as i64;
             let mut right = other.tow().to_bits() as i64;
 

--- a/swiftnav/src/time.rs
+++ b/swiftnav/src/time.rs
@@ -302,13 +302,7 @@ impl GpsTime {
     }
 
     pub fn total_cmp(&self, other: &GpsTime) -> Ordering {
-        if self == other {
-            Ordering::Equal
-        } else if self > other {
-            Ordering::Greater
-        } else {
-            Ordering::Less
-        }
+        self.tow().total_cmp(&other.tow())
     }
 }
 


### PR DESCRIPTION
Add a `total_cmp` method similar to the `f64::total_cmp` introduced in Rust 1.62 -- this should simplify operations that require sorting `GpsTime` values (and other related operations that require a total order).