### PR TITLE
Fix an errant clippy warning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,8 @@ name: CI
   push:
     branches:
       - "master"
+  schedule:
+    - cron: "0 16 * * 1" # 8am PST every Monday
 jobs:
   ci:
     name: Format, lint, and test

--- a/swiftnav/src/solver.rs
+++ b/swiftnav/src/solver.rs
@@ -396,7 +396,7 @@ pub fn calc_pvt(
     tor: GpsTime,
     settings: PvtSettings,
 ) -> Result<(PvtStatus, GnssSolution, Dops, SidSet), PvtError> {
-    assert!(measurements.len() <= std::u8::MAX as usize);
+    assert!(measurements.len() <= u8::MAX as usize);
 
     let mut solution = GnssSolution::new();
     let mut dops = Dops::new();


### PR DESCRIPTION
Seems like a recent update to Rust meant the `MAX` constant we were using moved and clippy started telling us to use the new preferred associated constant. This fixes that new clippy failure, and also updates the CI action to run on a weekly basis, hopefully that'll mean we catch these lint failures earlier and fix them before unrelated PRs get blocked by them.