### PR TITLE
Update Dependabot to also check for github action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,20 @@ updates:
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:
-    interval: daily
-    time: "13:00"
+    interval: weekly
+    time: "09:00"
+    timezone: "America/Los_Angeles"
   open-pull-requests-limit: 10
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: daily
-    time: "13:00"
+    interval: weekly
+    time: "09:00"
+    timezone: "America/Los_Angeles"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "09:00"
+    timezone: "America/Los_Angeles"
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,17 +6,21 @@ updates:
     interval: weekly
     time: "09:00"
     timezone: "America/Los_Angeles"
-  open-pull-requests-limit: 10
+  reviewers:
+    - swift-nav/open-source
 - package-ecosystem: cargo
   directory: "/"
   schedule:
     interval: weekly
     time: "09:00"
     timezone: "America/Los_Angeles"
+  reviewers:
+    - swift-nav/open-source
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: weekly
     time: "09:00"
     timezone: "America/Los_Angeles"
-  open-pull-requests-limit: 10
+  reviewers:
+    - swift-nav/open-source


### PR DESCRIPTION
Also have Dependabot tag the open-source team to review dependency updates. Also also drop the frequency to once a week.