### PR TITLE
Fix Rustup step in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,5 @@ jobs:
           rustup toolchain install --force-non-host ${{ matrix.toolchain }}-${{ matrix.binary_target }}
           rustup show
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: --no-workspace workspace-ci-flow
+      - name: Build
+        run: cargo make --no-workspace workspace-ci-flow

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,6 @@ jobs:
       - name: Install rust ${{ matrix.binary_target }}
         run: |
           rustup -V
-          rustup show
           rustup set profile minimal
           rustup toolchain install --force-non-host ${{ matrix.toolchain }}-${{ matrix.binary_target }}
           rustup show

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,10 +70,12 @@ jobs:
           echo $env:CMAKE_GENERATOR
 
       - name: Install rust ${{ matrix.binary_target }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}-${{ matrix.binary_target }}
-          profile: minimal
+        run: |
+          rustup -V
+          rustup show
+          rustup set profile minimal
+          rustup toolchain install ${{ matrix.toolchain }}-${{ matrix.binary_target }}
+          rustup show
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
           rustup -V
           rustup show
           rustup set profile minimal
-          rustup toolchain install ${{ matrix.toolchain }}-${{ matrix.binary_target }}
+          rustup toolchain install --force-non-host ${{ matrix.toolchain }}-${{ matrix.binary_target }}
           rustup show
 
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
Seems like we finally got hit by the rustup v1.28 changes (Github action runners likely updated between last week and now). We were previously using [actions-rs/toolchain](https://github.com/actions-rs/toolchain) but that has been archived for a while. Instead I've simply replaced that action with a couple of manual `rustup` commands.