### PR TITLE
Add a justfile

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+RUSTDOCFLAGS="--html-in-header katex-header.html -D warnings"
+RUSTFLAGS="-D warnings"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
+
+      - uses: extractions/setup-just@v3
+
       - name: Install rust
         run: |
           rustup -V
@@ -23,18 +26,16 @@ jobs:
           rustup show
 
       - name: Check Formatting
-        run: cargo fmt --check --all --verbose
+        run: just fmt-check
 
       - name: Clippy
-        run: cargo clippy --workspace --all-features --verbose -- -Dwarnings
+        run: just lint
 
       # Check for docs warnings
       # Only do this for the swiftnav crate since swiftnav-sys has some errors
       # in the bindgen output
       - name: Docs
-        env:
-          RUSTDOCFLAGS: -D warnings
-        run: cargo doc --package swiftnav --all-features --no-deps --verbose
+        run: just docs
 
   build:
     name: Build and test
@@ -68,6 +69,8 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: extractions/setup-just@v3
+
       - name: Install musl tools
         if: matrix.needs_musl
         run: |
@@ -97,7 +100,7 @@ jobs:
           rustup show
 
       - name: Build
-        run: cargo build --workspace --all-features --verbose
+        run: just build
 
       - name: Test
-        run: cargo test --workspace --all-features --verbose
+        run: just test

--- a/justfile
+++ b/justfile
@@ -1,0 +1,36 @@
+set dotenv-load
+
+# What is run by default when no command is given
+default: fmt lint test
+
+# Build
+build:
+    @cargo build --workspace --all-features
+
+# Run tests
+test:
+    @cargo test --workspace --all-features
+
+# Run cargo check
+check:
+    @cargo check --workspace --all-features
+
+# Format code
+fmt:
+    @cargo fmt --all
+
+# Check formatting without making changes
+fmt-check:
+    @cargo fmt --all --check
+
+# Lint code
+lint:
+    @cargo clippy --workspace --all-features
+
+# Generate docs
+docs:
+    @cargo doc  --workspace --all-features --no-deps
+
+# Generate and open docs
+open-docs:
+    @cargo doc  --workspace --all-features --no-deps --open

--- a/swiftnav-sys/src/lib.rs
+++ b/swiftnav-sys/src/lib.rs
@@ -14,4 +14,5 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 #![allow(deref_nullptr)]
+#![allow(rustdoc::broken_intra_doc_links)]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
We've got a couple of non-trivial commands to build docs with the proper katex headers. So why not add a `justfile` to help simplify common operations?