### PR TITLE
Add nice to have functions for coordindate types

### DIFF
--- a/swiftnav/README.md
+++ b/swiftnav/README.md
@@ -1,1 +1,22 @@
-../README.md
+# swiftnav
+
+`swiftnav` is a library that implements GNSS utility functions to perform
+position estimations. The data used by `swiftnav` typically comes from GNSS
+receiver chips as raw observation and ephemeris data. `swiftnav` is more of
+a "bring your own algorithm" library, it provides a bunch of functionality that
+is useful when processing raw GNSS data, but it provides only limited position
+estimation capabilities. Each module encompasses a single set of functionality,
+and they are meant to be pretty self-explanatory for developers familiar with
+GNSS processing.
+
+GNSS systems are used to estimate the location of the receiver by determining
+the distance between the receiver and several satellites. The satellites send
+out precisely timed periodic messages and the receiver measures the delay
+of those messages. Knowing the location of the satellites at the time of
+transmission and the delays of the messages the receiver is able to determine
+the location of itself in relation to the satellites.
+
+`swiftnav` does not provide any functionality for communicating with
+receivers made by Swift Navigation, or any manufacturer.
+[libsbp](https://github.com/swift-nav/libsbp) is the library to use if you
+want to communicate with receivers using Swift Binary Protocol (SBP).

--- a/swiftnav/src/coords/ecef.rs
+++ b/swiftnav/src/coords/ecef.rs
@@ -19,10 +19,28 @@ impl ECEF {
         Self(Vector3::new(x, y, z))
     }
 
-    /// Get a reference to the inner [`Vector3<f64>`]
+    /// Get a reference to the inner array storing the data
     #[must_use]
-    pub(crate) fn as_vector(&self) -> &Vector3<f64> {
+    pub fn as_array(&self) -> &[f64; 3] {
+        &self.0.data.0[0]
+    }
+
+    /// Get a mutable reference to the inner array storing the data
+    #[must_use]
+    pub fn as_array_mut(&mut self) -> &mut [f64; 3] {
+        &mut self.0.data.0[0]
+    }
+
+    /// Get a reference to the inner [`Vector3`] storing the data
+    #[must_use]
+    pub fn as_vector(&self) -> &Vector3<f64> {
         &self.0
+    }
+
+    /// Get a mutable reference to the inner [`Vector3`] storing the data
+    #[must_use]
+    pub fn as_vector_mut(&mut self) -> &mut Vector3<f64> {
+        &mut self.0
     }
 
     /// Get the X component

--- a/swiftnav/src/coords/ecef.rs
+++ b/swiftnav/src/coords/ecef.rs
@@ -233,6 +233,30 @@ impl From<LLHDegrees> for ECEF {
     }
 }
 
+impl AsRef<[f64; 3]> for ECEF {
+    fn as_ref(&self) -> &[f64; 3] {
+        self.as_array()
+    }
+}
+
+impl AsRef<Vector3<f64>> for ECEF {
+    fn as_ref(&self) -> &Vector3<f64> {
+        self.as_vector()
+    }
+}
+
+impl AsMut<[f64; 3]> for ECEF {
+    fn as_mut(&mut self) -> &mut [f64; 3] {
+        self.as_array_mut()
+    }
+}
+
+impl AsMut<Vector3<f64>> for ECEF {
+    fn as_mut(&mut self) -> &mut Vector3<f64> {
+        self.as_vector_mut()
+    }
+}
+
 impl Add for ECEF {
     type Output = Self;
     fn add(self, rhs: ECEF) -> Self {

--- a/swiftnav/src/coords/llh.rs
+++ b/swiftnav/src/coords/llh.rs
@@ -109,6 +109,30 @@ impl From<ECEF> for LLHDegrees {
     }
 }
 
+impl AsRef<[f64; 3]> for LLHDegrees {
+    fn as_ref(&self) -> &[f64; 3] {
+        self.as_array()
+    }
+}
+
+impl AsRef<Vector3<f64>> for LLHDegrees {
+    fn as_ref(&self) -> &Vector3<f64> {
+        self.as_vector()
+    }
+}
+
+impl AsMut<[f64; 3]> for LLHDegrees {
+    fn as_mut(&mut self) -> &mut [f64; 3] {
+        self.as_array_mut()
+    }
+}
+
+impl AsMut<Vector3<f64>> for LLHDegrees {
+    fn as_mut(&mut self) -> &mut Vector3<f64> {
+        self.as_vector_mut()
+    }
+}
+
 /// WGS84 geodetic coordinates (Latitude, Longitude, Height), with angles in radians.
 ///
 /// Internally stored as an array of 3 [f64](std::f64) values: latitude, longitude, and height above the ellipsoid in meters
@@ -222,5 +246,29 @@ impl From<LLHDegrees> for LLHRadians {
 impl From<ECEF> for LLHRadians {
     fn from(ecef: ECEF) -> Self {
         ecef.to_llh()
+    }
+}
+
+impl AsRef<[f64; 3]> for LLHRadians {
+    fn as_ref(&self) -> &[f64; 3] {
+        self.as_array()
+    }
+}
+
+impl AsRef<Vector3<f64>> for LLHRadians {
+    fn as_ref(&self) -> &Vector3<f64> {
+        self.as_vector()
+    }
+}
+
+impl AsMut<[f64; 3]> for LLHRadians {
+    fn as_mut(&mut self) -> &mut [f64; 3] {
+        self.as_array_mut()
+    }
+}
+
+impl AsMut<Vector3<f64>> for LLHRadians {
+    fn as_mut(&mut self) -> &mut Vector3<f64> {
+        self.as_vector_mut()
     }
 }

--- a/swiftnav/src/coords/llh.rs
+++ b/swiftnav/src/coords/llh.rs
@@ -14,6 +14,30 @@ impl LLHDegrees {
         Self(Vector3::new(lat, lon, height))
     }
 
+    /// Get a reference to the inner array storing the data
+    #[must_use]
+    pub fn as_array(&self) -> &[f64; 3] {
+        &self.0.data.0[0]
+    }
+
+    /// Get a mutable reference to the inner array storing the data
+    #[must_use]
+    pub fn as_array_mut(&mut self) -> &mut [f64; 3] {
+        &mut self.0.data.0[0]
+    }
+
+    /// Get a reference to the inner [`Vector3`] storing the data
+    #[must_use]
+    pub fn as_vector(&self) -> &Vector3<f64> {
+        &self.0
+    }
+
+    /// Get a mutable reference to the inner [`Vector3`] storing the data
+    #[must_use]
+    pub fn as_vector_mut(&mut self) -> &mut Vector3<f64> {
+        &mut self.0
+    }
+
     /// Get the latitude component
     #[must_use]
     pub fn latitude(&self) -> f64 {
@@ -96,6 +120,30 @@ impl LLHRadians {
     #[must_use]
     pub fn new(lat: f64, lon: f64, height: f64) -> Self {
         Self(Vector3::new(lat, lon, height))
+    }
+
+    /// Get a reference to the inner array storing the data
+    #[must_use]
+    pub fn as_array(&self) -> &[f64; 3] {
+        &self.0.data.0[0]
+    }
+
+    /// Get a mutable reference to the inner array storing the data
+    #[must_use]
+    pub fn as_array_mut(&mut self) -> &mut [f64; 3] {
+        &mut self.0.data.0[0]
+    }
+
+    /// Get a reference to the inner [`Vector3`] storing the data
+    #[must_use]
+    pub fn as_vector(&self) -> &Vector3<f64> {
+        &self.0
+    }
+
+    /// Get a mutable reference to the inner [`Vector3`] storing the data
+    #[must_use]
+    pub fn as_vector_mut(&mut self) -> &mut Vector3<f64> {
+        &mut self.0
     }
 
     /// Get the latitude component

--- a/swiftnav/src/coords/mod.rs
+++ b/swiftnav/src/coords/mod.rs
@@ -105,6 +105,30 @@ impl AzimuthElevation {
         Self(Vector2::new(az, el))
     }
 
+    /// Get a reference to the inner array storing the data
+    #[must_use]
+    pub fn as_array(&self) -> &[f64; 2] {
+        &self.0.data.0[0]
+    }
+
+    /// Get a mutable reference to the inner array storing the data
+    #[must_use]
+    pub fn as_array_mut(&mut self) -> &mut [f64; 2] {
+        &mut self.0.data.0[0]
+    }
+
+    /// Get a reference to the inner [`Vector2`] storing the data
+    #[must_use]
+    pub fn as_vector(&self) -> &Vector2<f64> {
+        &self.0
+    }
+
+    /// Get a mutable reference to the inner [`Vector2`] storing the data
+    #[must_use]
+    pub fn as_vector_mut(&mut self) -> &mut Vector2<f64> {
+        &mut self.0
+    }
+
     /// Get the Azimuth component
     #[must_use]
     pub fn az(&self) -> f64 {

--- a/swiftnav/src/coords/mod.rs
+++ b/swiftnav/src/coords/mod.rs
@@ -166,6 +166,30 @@ impl From<(f64, f64)> for AzimuthElevation {
     }
 }
 
+impl AsRef<[f64; 2]> for AzimuthElevation {
+    fn as_ref(&self) -> &[f64; 2] {
+        self.as_array()
+    }
+}
+
+impl AsRef<Vector2<f64>> for AzimuthElevation {
+    fn as_ref(&self) -> &Vector2<f64> {
+        self.as_vector()
+    }
+}
+
+impl AsMut<[f64; 2]> for AzimuthElevation {
+    fn as_mut(&mut self) -> &mut [f64; 2] {
+        self.as_array_mut()
+    }
+}
+
+impl AsMut<Vector2<f64>> for AzimuthElevation {
+    fn as_mut(&mut self) -> &mut Vector2<f64> {
+        self.as_vector_mut()
+    }
+}
+
 /// Complete coordinate used for transforming between reference frames
 ///
 /// Velocities are optional, but when present they will be transformed

--- a/swiftnav/src/coords/ned.rs
+++ b/swiftnav/src/coords/ned.rs
@@ -91,3 +91,27 @@ impl From<(f64, f64, f64)> for NED {
         Self::new(x, y, z)
     }
 }
+
+impl AsRef<[f64; 3]> for NED {
+    fn as_ref(&self) -> &[f64; 3] {
+        self.as_array()
+    }
+}
+
+impl AsRef<Vector3<f64>> for NED {
+    fn as_ref(&self) -> &Vector3<f64> {
+        self.as_vector()
+    }
+}
+
+impl AsMut<[f64; 3]> for NED {
+    fn as_mut(&mut self) -> &mut [f64; 3] {
+        self.as_array_mut()
+    }
+}
+
+impl AsMut<Vector3<f64>> for NED {
+    fn as_mut(&mut self) -> &mut Vector3<f64> {
+        self.as_vector_mut()
+    }
+}

--- a/swiftnav/src/coords/ned.rs
+++ b/swiftnav/src/coords/ned.rs
@@ -15,10 +15,28 @@ impl NED {
         NED(Vector3::new(n, e, d))
     }
 
-    /// Get a reference to the inner [`Vector3<f64>`]
+    /// Get a reference to the inner array storing the data
     #[must_use]
-    pub(crate) fn as_vector(&self) -> &Vector3<f64> {
+    pub fn as_array(&self) -> &[f64; 3] {
+        &self.0.data.0[0]
+    }
+
+    /// Get a mutable reference to the inner array storing the data
+    #[must_use]
+    pub fn as_array_mut(&mut self) -> &mut [f64; 3] {
+        &mut self.0.data.0[0]
+    }
+
+    /// Get a reference to the inner [`Vector3`] storing the data
+    #[must_use]
+    pub fn as_vector(&self) -> &Vector3<f64> {
         &self.0
+    }
+
+    /// Get a mutable reference to the inner [`Vector3`] storing the data
+    #[must_use]
+    pub fn as_vector_mut(&mut self) -> &mut Vector3<f64> {
+        &mut self.0
     }
 
     /// Get the north component


### PR DESCRIPTION
Think I got a little over zealous with the RIIR, and removed a couple of nice to have functions.

Is it acceptable to have multiple `AsRef` impls on a type? It seems like the stdlin does (e.g. `Vec` implements two different `AsRef`). Also is it preferable to not have dedicated functions and only rely on the `AsRef` impl for casting?