### PR TITLE
Set an environment variable to unblock cmake build for now

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,8 @@ on:
       - "master"
   schedule:
     - cron: "0 16 * * 1" # 8am PST every Monday
+env:
+  CMAKE_POLICY_VERSION_MINIMUM: 3.5
 jobs:
   lint:
     name: Lints


### PR DESCRIPTION
Master build [failed earlier](https://github.com/swift-nav/swiftnav-rs/actions/runs/17739419661), seems like the Github runners updated their CMake to a version that deprecates support for the minimum version used in the C library build.

We're in the middle of a refactor to remove the dependency on the C library, but to unblock further builds I've added an environment variable to work around the CMake build failure.