### PR TITLE
Fix new clippy warnings

### DIFF
--- a/swiftnav/src/time/gnss.rs
+++ b/swiftnav/src/time/gnss.rs
@@ -187,9 +187,9 @@ impl GpsTime {
         let mut utc_time: UtcTime = UtcTime::from_gps_no_leap(utc_time);
 
         if is_lse {
-            assert!(utc_time.hour() == 23);
-            assert!(utc_time.minute() == 59);
-            assert!(utc_time.seconds_int() == 59);
+            assert_eq!(utc_time.hour(), 23);
+            assert_eq!(utc_time.minute(), 59);
+            assert_eq!(utc_time.seconds_int(), 59);
             /* add the extra second back in */
             utc_time.add_second();
         }


### PR DESCRIPTION
Quick fix to a [new set of clippy warnings in 1.97](https://github.com/rust-lang/rust-clippy/blob/eed04f6e17d145cb281b6c1ea1a8755b49c6a05f/CHANGELOG.md?plain=1#L19-L20).