### PR TITLE
implement Display for all coordinate types [SKY-3772]

### DIFF
--- a/swiftnav/src/coords/ecef.rs
+++ b/swiftnav/src/coords/ecef.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 
 use nalgebra::Vector3;
@@ -356,9 +357,27 @@ impl MulAssign<&f64> for ECEF {
     }
 }
 
+impl fmt::Display for ECEF {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ECEF {{ x: {}, y: {}, z: {} }}",
+            self.x(),
+            self.y(),
+            self.z()
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn display_ecef() {
+        let test = ECEF::new(-1.5, 2.78, 3.0);
+        assert_eq!(format!("{test}"), "ECEF { x: -1.5, y: 2.78, z: 3 }");
+    }
 
     #[expect(clippy::float_cmp)]
     #[test]

--- a/swiftnav/src/coords/hemisphere.rs
+++ b/swiftnav/src/coords/hemisphere.rs
@@ -41,3 +41,32 @@ impl fmt::Display for Hemisphere {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_latitudinal_hemisphere() {
+        assert_eq!(format!("{}", LatitudinalHemisphere::North), "N");
+        assert_eq!(format!("{}", LatitudinalHemisphere::South), "S");
+    }
+
+    #[test]
+    fn display_longitudinal_hemisphere() {
+        assert_eq!(format!("{}", LongitudinalHemisphere::East), "E");
+        assert_eq!(format!("{}", LongitudinalHemisphere::West), "W");
+    }
+
+    #[test]
+    fn display_hemisphere() {
+        assert_eq!(
+            format!("{}", Hemisphere::Latitudinal(LatitudinalHemisphere::North)),
+            "N"
+        );
+        assert_eq!(
+            format!("{}", Hemisphere::Longitudinal(LongitudinalHemisphere::West)),
+            "W"
+        );
+    }
+}

--- a/swiftnav/src/coords/llh.rs
+++ b/swiftnav/src/coords/llh.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use nalgebra::Vector3;
 
 use super::{ECEF, Ellipsoid, WGS84};
@@ -188,6 +190,18 @@ impl AsMut<Vector3<f64>> for LLHDegrees {
     }
 }
 
+impl fmt::Display for LLHDegrees {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "LLHDegrees {{ lat: {}, lon: {}, ht: {} }}",
+            self.latitude(),
+            self.longitude(),
+            self.height()
+        )
+    }
+}
+
 /// WGS84 geodetic coordinates (Latitude, Longitude, Height), with angles in radians.
 ///
 /// Internally stored as an array of 3 [f64](std::f64) values: latitude, longitude, and height above
@@ -326,5 +340,40 @@ impl AsMut<[f64; 3]> for LLHRadians {
 impl AsMut<Vector3<f64>> for LLHRadians {
     fn as_mut(&mut self) -> &mut Vector3<f64> {
         self.as_vector_mut()
+    }
+}
+
+impl fmt::Display for LLHRadians {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "LLHRadians {{ lat: {}, lon: {}, ht: {} }}",
+            self.latitude(),
+            self.longitude(),
+            self.height()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_llh_degrees() {
+        let test = LLHDegrees::new(-1.5, 2.78, 3.0);
+        assert_eq!(
+            format!("{test}"),
+            "LLHDegrees { lat: -1.5, lon: 2.78, ht: 3 }"
+        );
+    }
+
+    #[test]
+    fn display_llh_radians() {
+        let llh = LLHRadians::new(-1.5, 2.78, 3.0);
+        assert_eq!(
+            format!("{llh}"),
+            "LLHRadians { lat: -1.5, lon: 2.78, ht: 3 }"
+        );
     }
 }

--- a/swiftnav/src/coords/mod.rs
+++ b/swiftnav/src/coords/mod.rs
@@ -87,6 +87,7 @@ use nalgebra::Vector2;
 pub use ned::*;
 
 use crate::{reference_frame::ReferenceFrame, time::GpsTime};
+use std::fmt;
 
 /// WGS84 local horizontal coordinates consisting of an Azimuth and Elevation, with angles stored as
 /// radians
@@ -191,6 +192,17 @@ impl AsMut<Vector2<f64>> for AzimuthElevation {
     }
 }
 
+impl fmt::Display for AzimuthElevation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "AzimuthElevation {{ az: {}, el: {} }}",
+            self.az(),
+            self.el()
+        )
+    }
+}
+
 /// Complete coordinate used for transforming between reference frames
 ///
 /// Velocities are optional, but when present they will be transformed
@@ -291,6 +303,30 @@ impl Coordinate {
     }
 }
 
+impl fmt::Display for Coordinate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.velocity {
+            Some(v) => write!(
+                f,
+                "Coordinate {{ ref_frame: {}, pos: {}, vel: {}, epoch: wn={} tow={} }}",
+                self.reference_frame,
+                self.position,
+                v,
+                self.epoch.wn(),
+                self.epoch.tow()
+            ),
+            None => write!(
+                f,
+                "Coordinate {{ ref_frame: {}, pos: {}, vel: None, epoch: wn={} tow={} }}",
+                self.reference_frame,
+                self.position,
+                self.epoch.wn(),
+                self.epoch.tow()
+            ),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use float_eq::assert_float_eq;
@@ -298,6 +334,49 @@ mod tests {
 
     use super::*;
     use crate::time::UtcTime;
+
+    #[test]
+    fn display_azimuth_elevation() {
+        let azel = AzimuthElevation::new(1.2, -2.1);
+        assert_eq!(format!("{azel}"), "AzimuthElevation { az: 1.2, el: -2.1 }");
+    }
+
+    #[test]
+    fn display_coordinate_with_velocity() {
+        let epoch = UtcTime::from_parts(2020, 1, 1, 0, 0, 0.).to_gps_hardcoded();
+        let coord = Coordinate::with_velocity(
+            ReferenceFrame::ITRF2014,
+            ECEF::new(1.0, 2.0, 3.0),
+            ECEF::new(4.0, 5.0, 6.0),
+            epoch,
+        );
+        assert_eq!(
+            format!("{coord}"),
+            format!(
+                "Coordinate {{ ref_frame: ITRF2014, pos: ECEF {{ x: 1, y: 2, z: 3 }}, vel: ECEF {{ x: 4, y: 5, z: 6 }}, epoch: wn={} tow={} }}",
+                epoch.wn(),
+                epoch.tow()
+            )
+        );
+    }
+
+    #[test]
+    fn display_coordinate() {
+        let epoch = UtcTime::from_parts(2020, 1, 1, 23, 2, 4.0).to_gps_hardcoded();
+        let coord = Coordinate::without_velocity(
+            ReferenceFrame::ITRF2020,
+            ECEF::new(-1.5, 2.78, 3.0),
+            epoch,
+        );
+        assert_eq!(
+            format!("{coord}"),
+            format!(
+                "Coordinate {{ ref_frame: ITRF2020, pos: ECEF {{ x: -1.5, y: 2.78, z: 3 }}, vel: None, epoch: wn={} tow={} }}",
+                epoch.wn(),
+                epoch.tow()
+            )
+        );
+    }
 
     /* Maximum allowable error in quantities with units of length (in meters). */
     const MAX_DIST_ERROR_M: f64 = 1e-6;

--- a/swiftnav/src/coords/ned.rs
+++ b/swiftnav/src/coords/ned.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use nalgebra::Vector3;
 
 use crate::{coords::ECEF, math};
@@ -113,5 +115,28 @@ impl AsMut<[f64; 3]> for NED {
 impl AsMut<Vector3<f64>> for NED {
     fn as_mut(&mut self) -> &mut Vector3<f64> {
         self.as_vector_mut()
+    }
+}
+
+impl fmt::Display for NED {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "NED {{ N: {}, E: {}, D: {} }}",
+            self.n(),
+            self.e(),
+            self.d()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_ned() {
+        let test = NED::new(-1.5, 2.78, 3.0);
+        assert_eq!(format!("{test}"), "NED { N: -1.5, E: 2.78, D: 3 }");
     }
 }


### PR DESCRIPTION
Implement display for all the coordinate types in https://github.com/swift-nav/swiftnav-rs/tree/master/swiftnav/src/coords, except for https://github.com/swift-nav/swiftnav-rs/blob/master/swiftnav/src/coords/ellipsoid.rs - I skipped this file since its just constants