### PR TITLE
Update some Display impls to respect precision request.

### DIFF
--- a/swiftnav/src/coords/ecef.rs
+++ b/swiftnav/src/coords/ecef.rs
@@ -359,13 +359,23 @@ impl MulAssign<&f64> for ECEF {
 
 impl fmt::Display for ECEF {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "ECEF {{ x: {}, y: {}, z: {} }}",
-            self.x(),
-            self.y(),
-            self.z()
-        )
+        if let Some(decimals) = f.precision() {
+            write!(
+                f,
+                "ECEF {{ x: {:.decimals$}, y: {:.decimals$}, z: {:.decimals$} }}",
+                self.x(),
+                self.y(),
+                self.z()
+            )
+        } else {
+            write!(
+                f,
+                "ECEF {{ x: {}, y: {}, z: {} }}",
+                self.x(),
+                self.y(),
+                self.z()
+            )
+        }
     }
 }
 
@@ -377,6 +387,11 @@ mod tests {
     fn display_ecef() {
         let test = ECEF::new(-1.5, 2.78, 3.0);
         assert_eq!(format!("{test}"), "ECEF { x: -1.5, y: 2.78, z: 3 }");
+        assert_eq!(format!("{test:.1}"), "ECEF { x: -1.5, y: 2.8, z: 3.0 }");
+        assert_eq!(
+            format!("{test:.3}"),
+            "ECEF { x: -1.500, y: 2.780, z: 3.000 }"
+        );
     }
 
     #[expect(clippy::float_cmp)]

--- a/swiftnav/src/coords/mod.rs
+++ b/swiftnav/src/coords/mod.rs
@@ -194,12 +194,21 @@ impl AsMut<Vector2<f64>> for AzimuthElevation {
 
 impl fmt::Display for AzimuthElevation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "AzimuthElevation {{ az: {}, el: {} }}",
-            self.az(),
-            self.el()
-        )
+        if let Some(decimals) = f.precision() {
+            write!(
+                f,
+                "AzimuthElevation {{ az: {:.decimals$}, el: {:.decimals$} }}",
+                self.az(),
+                self.el()
+            )
+        } else {
+            write!(
+                f,
+                "AzimuthElevation {{ az: {}, el: {} }}",
+                self.az(),
+                self.el()
+            )
+        }
     }
 }
 
@@ -339,6 +348,14 @@ mod tests {
     fn display_azimuth_elevation() {
         let azel = AzimuthElevation::new(1.2, -2.1);
         assert_eq!(format!("{azel}"), "AzimuthElevation { az: 1.2, el: -2.1 }");
+        assert_eq!(
+            format!("{azel:.1}"),
+            "AzimuthElevation { az: 1.2, el: -2.1 }"
+        );
+        assert_eq!(
+            format!("{azel:.3}"),
+            "AzimuthElevation { az: 1.200, el: -2.100 }"
+        );
     }
 
     #[test]

--- a/swiftnav/src/coords/ned.rs
+++ b/swiftnav/src/coords/ned.rs
@@ -120,13 +120,23 @@ impl AsMut<Vector3<f64>> for NED {
 
 impl fmt::Display for NED {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "NED {{ N: {}, E: {}, D: {} }}",
-            self.n(),
-            self.e(),
-            self.d()
-        )
+        if let Some(decimals) = f.precision() {
+            write!(
+                f,
+                "NED {{ N: {:.decimals$}, E: {:.decimals$}, D: {:.decimals$} }}",
+                self.n(),
+                self.e(),
+                self.d()
+            )
+        } else {
+            write!(
+                f,
+                "NED {{ N: {}, E: {}, D: {} }}",
+                self.n(),
+                self.e(),
+                self.d()
+            )
+        }
     }
 }
 
@@ -138,5 +148,10 @@ mod tests {
     fn display_ned() {
         let test = NED::new(-1.5, 2.78, 3.0);
         assert_eq!(format!("{test}"), "NED { N: -1.5, E: 2.78, D: 3 }");
+        assert_eq!(format!("{test:.1}"), "NED { N: -1.5, E: 2.8, D: 3.0 }");
+        assert_eq!(
+            format!("{test:.3}"),
+            "NED { N: -1.500, E: 2.780, D: 3.000 }"
+        );
     }
 }


### PR DESCRIPTION
The ECEF, NED, and AzEl coordinate types have their Display trait implementations updated to respect the requested precision if one is provided. If none is provided the default floating point formatting is used. Other coordinate types aren't updated since they consist of heterogeneous units which makes it difficult to apply a single precision argument to them. They can be updated if a clear approach can be determined.